### PR TITLE
fix: address review comments on PR #2751

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -525,9 +525,7 @@ class TensorMemoryObj(MemoryObj):
         return self.valid
 
     def get_size(self) -> int:
-        # Use raw_data actual size to handle partial chunks correctly
-        # (e.g. after reshape_partial_chunk which truncates raw_data)
-        return self.raw_data.numel() * self.raw_data.element_size()
+        return self.group_prefix_sum[-1]
 
     # TODO(chunxiaozheng): use get_shapes and get_dtypes to replace
     #  get_shape and get_dtype

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -525,7 +525,9 @@ class TensorMemoryObj(MemoryObj):
         return self.valid
 
     def get_size(self) -> int:
-        return self.group_prefix_sum[-1]
+        # Use raw_data actual size to handle partial chunks correctly
+        # (e.g. after reshape_partial_chunk which truncates raw_data)
+        return self.raw_data.numel() * self.raw_data.element_size()
 
     # TODO(chunxiaozheng): use get_shapes and get_dtypes to replace
     #  get_shape and get_dtype

--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -96,6 +96,49 @@ def get_remote_metadata_bytes():
     return REMOTE_METADATA_BYTES
 
 
+def pad_shape_to_4d(shape: torch.Size) -> list[int]:
+    """Pad a shape with fewer than 4 dimensions to 4D using trailing
+    zeros.
+
+    Shapes that are already 4D are returned as-is.  For shapes with
+    fewer dimensions the missing trailing slots are filled with ``0``.
+    This is consistent with the convention used by
+    :class:`BinaryMemoryObj` (``[length, 0, 0, 0]``).
+
+    Args:
+        shape: The original tensor shape (1-D to 4-D).
+
+    Returns:
+        A list of exactly 4 integers representing the padded shape.
+
+    Raises:
+        AssertionError: If the shape has more than 4 dimensions.
+    """
+    assert len(shape) <= 4, (
+        f"Shape dimension must be <= 4 for serialization, got {len(shape)}"
+    )
+    padded = list(shape) + [0] * (4 - len(shape))
+    return padded
+
+
+def strip_shape_padding(dims: list[int]) -> torch.Size:
+    """Strip trailing-zero padding that was added by
+    :func:`pad_shape_to_4d`.
+
+    Trailing zeros are removed so that the original dimensionality is
+    restored.  At least one dimension is always preserved.
+
+    Args:
+        dims: A list of 4 integers read from the serialized format.
+
+    Returns:
+        A :class:`torch.Size` with the padding removed.
+    """
+    while len(dims) > 1 and dims[-1] == 0:
+        dims.pop()
+    return torch.Size(dims)
+
+
 @dataclass
 class RemoteMetadata:
     length: int
@@ -103,53 +146,10 @@ class RemoteMetadata:
     dtypes: list[torch.dtype]
     fmt: MemoryFormat
 
-    @staticmethod
-    def _pad_shape_to_4d(shape: torch.Size) -> list[int]:
-        """Pad a shape with fewer than 4 dimensions to 4D using trailing
-        zeros.
-
-        Shapes that are already 4D are returned as-is.  For shapes with
-        fewer dimensions the missing trailing slots are filled with ``0``.
-        This is consistent with the convention used by
-        :class:`BinaryMemoryObj` (``[length, 0, 0, 0]``).
-
-        Args:
-            shape: The original tensor shape (1-D to 4-D).
-
-        Returns:
-            A list of exactly 4 integers representing the padded shape.
-
-        Raises:
-            AssertionError: If the shape has more than 4 dimensions.
-        """
-        assert len(shape) <= 4, (
-            f"Shape dimension must be <= 4 for serialization, got {len(shape)}"
-        )
-        padded = list(shape) + [0] * (4 - len(shape))
-        return padded
-
-    @staticmethod
-    def _strip_shape_padding(dims: list[int]) -> torch.Size:
-        """Strip trailing-zero padding that was added by
-        :meth:`_pad_shape_to_4d`.
-
-        Trailing zeros are removed so that the original dimensionality is
-        restored.  At least one dimension is always preserved.
-
-        Args:
-            dims: A list of 4 integers read from the serialized format.
-
-        Returns:
-            A :class:`torch.Size` with the padding removed.
-        """
-        while len(dims) > 1 and dims[-1] == 0:
-            dims.pop()
-        return torch.Size(dims)
-
     def _prepare_params(self):
         params = [self.length, int(self.fmt.value)]
         for shape, dtype in zip(self.shapes, self.dtypes, strict=True):
-            padded = self._pad_shape_to_4d(shape)
+            padded = pad_shape_to_4d(shape)
             params.append(DTYPE_TO_INT[dtype])
             params.extend(padded)
         return params
@@ -176,7 +176,7 @@ class RemoteMetadata:
         dtypes = []
         for i in range(2, len(result), 5):
             dims = list(result[i + 1 : i + 5])
-            shapes.append(RemoteMetadata._strip_shape_padding(dims))
+            shapes.append(strip_shape_padding(dims))
             dtypes.append(INT_TO_DTYPE[result[i]])
 
         return RemoteMetadata(
@@ -212,7 +212,7 @@ class ClientMetaMessage:
 
         # NOTE(Jiayi): 4 is the maximum dimension of memory object.
         # Pass in shape [x, 0, 0, 0] if it is a bytes memory object
-        padded = RemoteMetadata._pad_shape_to_4d(self.shape)
+        padded = pad_shape_to_4d(self.shape)
 
         packed_bytes = struct.pack(
             f"iiiiiiiii{MAX_KEY_LENGTH}s",
@@ -234,7 +234,7 @@ class ClientMetaMessage:
         command, length, fmt, dtype, location, shape0, shape1, shape2, shape3, key = (
             struct.unpack(f"iiiiiiiii{MAX_KEY_LENGTH}s", s)
         )
-        shape = RemoteMetadata._strip_shape_padding([shape0, shape1, shape2, shape3])
+        shape = strip_shape_padding([shape0, shape1, shape2, shape3])
         return ClientMetaMessage(
             ClientCommand(command),
             parse_cache_key(key.decode().strip()),
@@ -265,7 +265,7 @@ class ServerMetaMessage:
     location: Optional[str] = None
 
     def serialize(self) -> bytes:
-        padded = RemoteMetadata._pad_shape_to_4d(self.shape)
+        padded = pad_shape_to_4d(self.shape)
         packed_bytes = struct.pack(
             "iiiiiiiii",
             self.code.value,
@@ -289,7 +289,7 @@ class ServerMetaMessage:
         code, length, fmt, dtype, shape0, shape1, shape2, shape3, location = (
             struct.unpack("iiiiiiiii", s)
         )
-        shape = RemoteMetadata._strip_shape_padding([shape0, shape1, shape2, shape3])
+        shape = strip_shape_padding([shape0, shape1, shape2, shape3])
         return ServerMetaMessage(
             ServerReturnCode(code),
             length,

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -111,6 +111,10 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         actual_shape = torch.Size(shape_list)
         memory_obj.raw_data = memory_obj.raw_data[:bytes_read]
         memory_obj.meta.shape = actual_shape
+        # Sync group_prefix_sum so that get_size() / byte_array reflect the
+        # truncated size rather than the original full-chunk size.
+        if hasattr(memory_obj, "group_prefix_sum"):
+            memory_obj.group_prefix_sum = [0, bytes_read]  # type: ignore[attr-defined]
 
         return memory_obj
 


### PR DESCRIPTION
## Summary

This PR fixes two issues identified in review comments on LMCache/LMCache#2751.

### Fix 1: `byte_array` out-of-bounds for partial chunks (Medium)

**File**: `lmcache/v1/memory_management.py`

`TensorMemoryObj.get_size()` previously returned `group_prefix_sum[-1]`, which is computed once at `__init__` time. When `reshape_partial_chunk` (in `base_connector.py`) truncates `raw_data` and updates `meta.shape`, `group_prefix_sum` is not updated. Calling `byte_array` after `reshape_partial_chunk` would read beyond the truncated `raw_data` buffer.

**Fix**: `get_size()` now computes the size directly from `raw_data`:
```python
def get_size(self) -> int:
    # Use raw_data actual size to handle partial chunks correctly
    # (e.g. after reshape_partial_chunk which truncates raw_data)
    return self.raw_data.numel() * self.raw_data.element_size()
```
`group_prefix_sum` is preserved as it is still used by `get_tensor(index)`.

### Fix 2: Cross-class access to private methods (Low)

**File**: `lmcache/v1/protocol.py`

`ClientMetaMessage` and `ServerMetaMessage` were calling `RemoteMetadata._pad_shape_to_4d()` and `RemoteMetadata._strip_shape_padding()` — private methods accessed from outside their owning class.

**Fix**: Moved both methods to module-level functions (`pad_shape_to_4d` and `strip_shape_padding`), and updated all call sites in `RemoteMetadata._prepare_params`, `RemoteMetadata.deserialize`, `ClientMetaMessage.serialize`, `ClientMetaMessage.deserialize`, `ServerMetaMessage.serialize`, and `ServerMetaMessage.deserialize`.