### PR TITLE
fix(pd_backend): use run_in_executor for sync proxy_side_channel.send in async coroutine

### DIFF
--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -3,13 +3,14 @@
 # Standard
 from dataclasses import dataclass
 from typing import Any, Callable, List, Optional, Sequence, Union
+import asyncio
 import threading
-import time
 
 # Third Party
 import msgspec
 import torch
 import zmq
+import zmq.asyncio
 
 # First Party
 from lmcache.integration.vllm.utils import get_size_bytes
@@ -191,7 +192,7 @@ class PDBackend(AllocatorBackendInterface):
             else self.memory_allocator.gpu_allocator
         )
         self.transfer_channel = CreateTransferChannel(
-            async_mode=False,
+            async_mode=True,
             channel_type=config.transfer_channel,
             role=self.pd_config.role,
             buffer_ptr=allocator.buffer_ptr,
@@ -206,7 +207,18 @@ class PDBackend(AllocatorBackendInterface):
         if self.pd_config.role == "sender":
             self._init_sender()
             self.initialized_peers: set[str] = set()
-            self.mem_alloc_sockets: dict[str, zmq.Socket] = {}
+            # Dedicated asyncio event loop for async transfers
+            self._sender_loop = asyncio.new_event_loop()
+            self._sender_thread = threading.Thread(
+                target=self._sender_loop.run_forever,
+                daemon=True,
+                name="pd-sender-async",
+            )
+            self._sender_thread.start()
+            # Separate async ZMQ context for sender coroutines
+            self._async_zmq_context = zmq.asyncio.Context()
+            self._async_alloc_sockets: dict[str, zmq.asyncio.Socket] = {}
+            self._async_alloc_locks: dict[str, asyncio.Lock] = {}
         elif self.pd_config.role == "receiver":
             self._init_receiver()
         else:
@@ -349,26 +361,32 @@ class PDBackend(AllocatorBackendInterface):
             local_id=self.local_id, peer_id=receiver_id, peer_init_url=receiver_init_url
         )
 
-        # Set up the memory allocation socket
-        mem_alloc_socket = get_zmq_socket(
-            self.zmq_context,
-            receiver_mem_alloc_url,
-            "tcp",
-            zmq.REQ,
-            "connect",
+        # Schedule socket creation on the sender event loop to avoid cross-thread issues
+        future = asyncio.run_coroutine_threadsafe(
+            self._async_create_alloc_socket(receiver_id, receiver_mem_alloc_url),
+            self._sender_loop,
         )
-        self.mem_alloc_sockets[receiver_id] = mem_alloc_socket
+        future.result(timeout=10)  # Wait for socket to be created
 
         self.initialized_peers.add(receiver_id)
 
-    def _remote_allocate(
+    async def _async_create_alloc_socket(
+        self, receiver_id: str, receiver_mem_alloc_url: str
+    ):
+        async_alloc_socket = self._async_zmq_context.socket(zmq.REQ)
+        async_alloc_socket.connect(f"tcp://{receiver_mem_alloc_url}")
+        self._async_alloc_sockets[receiver_id] = async_alloc_socket
+
+    async def _async_remote_allocate(
         self, receiver_id: str, alloc_request: AllocRequest
     ) -> AllocResponse:
-        side_channel = self.mem_alloc_sockets[receiver_id]
-        side_channel.send(msgspec.msgpack.encode(alloc_request))
-        msg = side_channel.recv()
+        if receiver_id not in self._async_alloc_locks:
+            self._async_alloc_locks[receiver_id] = asyncio.Lock()
+        async with self._async_alloc_locks[receiver_id]:
+            socket = self._async_alloc_sockets[receiver_id]
+            await socket.send(msgspec.msgpack.encode(alloc_request))
+            msg = await socket.recv()
         alloc_response = msgspec.msgpack.decode(msg, type=PDMsg)
-
         return alloc_response
 
     def _get_remote_alloc_request(
@@ -401,7 +419,80 @@ class PDBackend(AllocatorBackendInterface):
             last_chunk_toks=last_chunk_toks,
         )
 
-    # TODO(Jiayi): make this async in the future
+    async def _async_transfer_task(
+        self,
+        keys: Sequence[CacheEngineKey],
+        memory_objs: List[MemoryObj],
+        receiver_id: str,
+        on_complete_callback: Optional[Callable[[CacheEngineKey], None]],
+        transfer_spec: Any = None,
+    ) -> None:
+        """
+        Async coroutine that performs the full KV transfer:
+        remote alloc → async_batched_write → ref_count_down → callback.
+        Runs in the dedicated sender event loop (_sender_loop).
+        """
+        completed_indexes: set[int] = set()
+        try:
+            alloc_request = self._get_remote_alloc_request(keys, memory_objs)
+            alloc_response = await self._async_remote_allocate(
+                receiver_id, alloc_request
+            )
+            already_sent_indexes = alloc_response.already_sent_indexes
+            remote_indexes = alloc_response.remote_indexes
+
+            mem_objs_to_send = []
+            for idx, mem_obj in enumerate(memory_objs):
+                if idx in already_sent_indexes:
+                    mem_obj.ref_count_down()
+                    completed_indexes.add(idx)
+                else:
+                    mem_objs_to_send.append(mem_obj)
+
+            if mem_objs_to_send:
+                channel_transfer_spec = {
+                    "receiver_id": receiver_id,
+                    "remote_indexes": remote_indexes,
+                }
+                await self.transfer_channel.async_batched_write(
+                    objects=mem_objs_to_send,
+                    transfer_spec=channel_transfer_spec,
+                )
+                for idx, mem_obj in enumerate(memory_objs):
+                    if idx not in completed_indexes:
+                        mem_obj.ref_count_down()
+                        completed_indexes.add(idx)
+            else:
+                logger.debug(
+                    "All memory objects have been already sent to the remote peer."
+                    " Skipping transfer."
+                )
+
+            if on_complete_callback is not None:
+                for key in keys:
+                    try:
+                        on_complete_callback(key)
+                    except Exception as e:
+                        logger.warning(
+                            f"on_complete_callback failed for key {key}: {e}"
+                        )
+
+            if transfer_spec is not None and getattr(
+                transfer_spec, "is_last_prefill", False
+            ):
+                notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
+                notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
+                self.proxy_side_channel.send(notif_msg_bytes)
+        except Exception as e:
+            logger.error("Async transfer task failed: %s", str(e))
+            # Release ref counts on error to avoid leaks (only those not yet released)
+            for idx, mem_obj in enumerate(memory_objs):
+                if idx not in completed_indexes:
+                    try:
+                        mem_obj.ref_count_down()
+                    except Exception:
+                        pass
+
     def batched_submit_put_task(
         self,
         keys: Sequence[CacheEngineKey],
@@ -412,9 +503,16 @@ class PDBackend(AllocatorBackendInterface):
         """
         Submit batched put tasks to transfer KV caches to peer.
 
+        Non-blocking: fires the async transfer coroutine to the background
+        event loop and returns immediately. The caller's ref_count_down will
+        happen concurrently with the async transfer, so we ref_count_up here
+        to keep objects alive until the async task completes.
+
         :param on_complete_callback: Optional callback invoked once per key
             after the transfer completes. Callback exceptions are caught and logged.
         """
+        # Bump ref counts so objects stay alive while async transfer is in-flight.
+        # The async task (_async_transfer_task) will call ref_count_down when done.
         for mem_obj in memory_objs:
             mem_obj.ref_count_up()
 
@@ -430,58 +528,17 @@ class PDBackend(AllocatorBackendInterface):
             receiver_alloc_port=receiver_alloc_port,
         )
 
-        # Allocate remote memory objects
-        alloc_request = self._get_remote_alloc_request(keys, memory_objs)
-        alloc_response = self._remote_allocate(receiver_id, alloc_request)
-        already_sent_indexes = alloc_response.already_sent_indexes
-        remote_indexes = alloc_response.remote_indexes
-
-        # Filter out already sent memory objects and free them
-        mem_objs_to_send = []
-        for idx, mem_obj in enumerate(memory_objs):
-            if idx in already_sent_indexes:
-                mem_obj.ref_count_down()
-            else:
-                mem_objs_to_send.append(mem_obj)
-
-        if mem_objs_to_send:
-            # TODO(Jiayi): make this decoupled with transfer channel
-            # Construct transfer spec
-            channel_transfer_spec = {
-                "receiver_id": receiver_id,
-                "remote_indexes": remote_indexes,
-            }
-
-            # TODO(Jiayi): Consider making this real async
-            # Perform the actual transfer
-            self.transfer_channel.batched_write(
-                objects=mem_objs_to_send,
-                transfer_spec=channel_transfer_spec,
-            )
-
-            # TODO(Jiayi): consider moving this to the transfer channel
-            # since we might want the transfer to be async.
-            for mem_obj in mem_objs_to_send:
-                mem_obj.ref_count_down()
-        else:
-            logger.debug(
-                "All memory objects have been already sent to the remote peer."
-                " Skipping transfer."
-            )
-
-        if transfer_spec.is_last_prefill:
-            # Notify the proxy that the transfer is done
-            notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
-            notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
-            self.proxy_side_channel.send(notif_msg_bytes)
-
-        # Call completion callback for all keys after transfer completes
-        if on_complete_callback is not None:
-            for key in keys:
-                try:
-                    on_complete_callback(key)
-                except Exception as e:
-                    logger.warning(f"on_complete_callback failed for key {key}: {e}")
+        # Fire-and-forget: submit to background asyncio event loop
+        asyncio.run_coroutine_threadsafe(
+            self._async_transfer_task(
+                keys=keys,
+                memory_objs=list(memory_objs),
+                receiver_id=receiver_id,
+                on_complete_callback=on_complete_callback,
+                transfer_spec=transfer_spec,
+            ),
+            self._sender_loop,
+        )
 
     ############################################################
     # Prefiller functions end
@@ -491,90 +548,98 @@ class PDBackend(AllocatorBackendInterface):
     # Decoder functions
     ############################################################
     def _init_receiver(self):
-        # Initialize initialization side channels
-        receiver_alloc_url = (
-            f"{self.pd_config.peer_host}:{self.pd_config.peer_alloc_port}"
+        """
+        Start a dedicated asyncio event loop in a background daemon thread
+        and launch the async memory allocation server coroutine.
+        """
+        self._recv_loop = asyncio.new_event_loop()
+        self._recv_thread = threading.Thread(
+            target=self._recv_loop.run_forever,
+            daemon=True,
+            name="pd-receiver-async",
         )
-        self.alloc_side_channel = get_zmq_socket(
-            self.zmq_context, receiver_alloc_url, "tcp", zmq.REP, "bind"
+        self._recv_thread.start()
+        asyncio.run_coroutine_threadsafe(
+            self._async_mem_alloc_server(), self._recv_loop
         )
-        self.side_channels.append(self.alloc_side_channel)
 
-        # Start the memory allocation thread
-        self.mem_alloc_thread = threading.Thread(
-            target=self._mem_alloc_loop, daemon=True
-        )
-        self.mem_alloc_thread.start()
-        self.running_threads.append(self.mem_alloc_thread)
+    async def _async_mem_alloc_server(self):
+        """
+        Async ZMQ REP server for memory allocation requests.
+        Replaces the blocking _mem_alloc_loop / _mem_alloc_thread.
+        When _async_allocate_and_put needs to wait for free memory it yields
+        via `await asyncio.sleep`, keeping the event loop responsive.
+        """
+        # Third Party
+        import zmq.asyncio as azmq
 
-    def _allocate_and_put(self, alloc_request: AllocRequest) -> AllocResponse:
+        async_ctx = azmq.Context()
+        socket = async_ctx.socket(zmq.REP)
+        alloc_port = self.pd_config.peer_alloc_port
+        socket.bind(f"tcp://*:{alloc_port}")
+        logger.info(f"Async mem alloc server listening on port {alloc_port}")
+        try:
+            while self.running:
+                try:
+                    alloc_req_bytes = await socket.recv()
+                    alloc_req = msgspec.msgpack.decode(alloc_req_bytes, type=PDMsg)
+                    assert isinstance(alloc_req, AllocRequest), (
+                        "The request from the remote peer is not an AllocRequest"
+                    )
+                    # NOTE: it's okay to put the memory objs into the storage backend
+                    # first because decode vllm will not be able to see the decode
+                    # request until proxy receives the ack.
+                    alloc_resp = await self._async_allocate_and_put(alloc_req)
+                    await socket.send(msgspec.msgpack.encode(alloc_resp))
+                except Exception as e:
+                    logger.error("Failed to process async mem alloc: %s", str(e))
+                    if self.running:
+                        await asyncio.sleep(0.01)
+        finally:
+            socket.close()
+            async_ctx.term()
+
+    async def _async_allocate_and_put(
+        self, alloc_request: AllocRequest
+    ) -> AllocResponse:
+        """
+        Async version of _allocate_and_put.
+        Uses `await asyncio.sleep` instead of `time.sleep` so the event loop
+        can continue processing while waiting for free memory.
+        pin=False: PDBackend has no eviction; pinning is unnecessary and
+        causes ref_count leaks.
+        """
         total_allocs = len(alloc_request.keys)
         fmt = MemoryFormat(alloc_request.fmt)
         dtype = STR_DTYPE_TO_TORCH_DTYPE[alloc_request.dtype]
-        shape = alloc_request.shape
+        shape = list(alloc_request.shape)  # copy — we mutate token_dim
 
         alloc_indexes = []
         already_send_indexes = []
 
         for idx, key_str in enumerate(alloc_request.keys):
             key = CacheEngineKey.from_string(key_str)
-            if self.contains(key, pin=True):
+            if self.contains(key, pin=False):  # pin=False: no eviction in PDBackend
                 already_send_indexes.append(idx)
                 continue
 
             if idx == total_allocs - 1:
-                num_alloc_tokens = alloc_request.last_chunk_toks
                 token_dim = fmt.token_dim()
-                shape[token_dim] = num_alloc_tokens
-            else:
-                num_alloc_tokens = self.full_chunk_size_bytes
+                shape[token_dim] = alloc_request.last_chunk_toks
 
             mem_obj = self.allocate(torch.Size(shape), dtype, fmt)
-
-            # TODO(Jiayi): make busy loop allocation part of
-            # memory allocator instead of backend as both PD
-            # and CPU offloading might need this.
             wait_time = 0.01
             while mem_obj is None:
-                logger.warning(
-                    "Failed to allocate memory object, retrying...",
-                )
-                time.sleep(wait_time)
+                logger.warning("Failed to allocate memory object, retrying...")
+                await asyncio.sleep(wait_time)
                 mem_obj = self.allocate(torch.Size(shape), dtype, fmt)
 
             alloc_indexes.append(mem_obj.meta.address)
-
             self.put(key, mem_obj)
 
         return AllocResponse(
             already_sent_indexes=already_send_indexes, remote_indexes=alloc_indexes
         )
-
-    def _mem_alloc_loop(self):
-        """
-        Running the memory allocation loop.
-        """
-        while self.running:
-            try:
-                # receive alloc request
-                alloc_req_bytes = self.alloc_side_channel.recv()
-                alloc_req = msgspec.msgpack.decode(alloc_req_bytes, type=PDMsg)
-                assert isinstance(alloc_req, AllocRequest), (
-                    "The request from the remote peer is not a AllocRequest"
-                )
-
-                # NOTE: it's okay to put the memory objs into the storage backend
-                # first because decode vllm will not be able to see the decode
-                # request until proxy receives the ack.
-                alloc_resp = self._allocate_and_put(alloc_req)
-
-                # send back response
-                self.alloc_side_channel.send(msgspec.msgpack.encode(alloc_resp))
-
-            except Exception as e:
-                logger.error("Failed to process mem alloc loop: %s", str(e))
-                if self.running:
-                    time.sleep(0.01)
 
     def put(
         self,
@@ -622,6 +687,24 @@ class PDBackend(AllocatorBackendInterface):
         self.running = False
         for thread in self.running_threads:
             thread.join()
+        # Shut down sender async loop if present
+        if hasattr(self, "_sender_loop"):
+            self._sender_loop.call_soon_threadsafe(self._sender_loop.stop)
+            self._sender_thread.join(timeout=5)
+            # Close async alloc sockets
+            for sock in self._async_alloc_sockets.values():
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+            try:
+                self._async_zmq_context.term()
+            except Exception:
+                pass
+        # Shut down receiver async loop if present
+        if hasattr(self, "_recv_loop"):
+            self._recv_loop.call_soon_threadsafe(self._recv_loop.stop)
+            self._recv_thread.join(timeout=5)
         self.transfer_channel.close()
         self.zmq_context.term()
 

--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -468,6 +468,13 @@ class PDBackend(AllocatorBackendInterface):
                     " Skipping transfer."
                 )
 
+            if transfer_spec is not None and getattr(
+                transfer_spec, "is_last_prefill", False
+            ):
+                notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
+                notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
+                self.proxy_side_channel.send(notif_msg_bytes)
+
             if on_complete_callback is not None:
                 for key in keys:
                     try:
@@ -476,13 +483,6 @@ class PDBackend(AllocatorBackendInterface):
                         logger.warning(
                             f"on_complete_callback failed for key {key}: {e}"
                         )
-
-            if transfer_spec is not None and getattr(
-                transfer_spec, "is_last_prefill", False
-            ):
-                notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
-                notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
-                self.proxy_side_channel.send(notif_msg_bytes)
         except Exception as e:
             logger.error("Async transfer task failed: %s", str(e))
             # Release ref counts on error to avoid leaks (only those not yet released)

--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -473,7 +473,10 @@ class PDBackend(AllocatorBackendInterface):
             ):
                 notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
                 notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
-                self.proxy_side_channel.send(notif_msg_bytes)
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(
+                    None, self.proxy_side_channel.send, notif_msg_bytes
+                )
 
             if on_complete_callback is not None:
                 for key in keys:

--- a/tests/v1/storage_backend/test_pd_backend_async.py
+++ b/tests/v1/storage_backend/test_pd_backend_async.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests proving that the async PDBackend sender and receiver execute
+transfers/allocations asynchronously.
+
+Design philosophy
+-----------------
+These tests do NOT require NIXL, CUDA, or real ZMQ peers. All I/O is mocked
+with asyncio.sleep() stubs so:
+  - Tests run fast (< 1 s total) in CI
+  - Assertions focus on *timing* and *call-ordering*, not data integrity
+    (data integrity is covered by the NIXL integration tests)
+
+Sender properties verified (PR #139 / async-pd-sender):
+  1. **Fire-and-forget**: `batched_submit_put_task` returns *before* the
+     transfer coroutine completes (proves non-blocking).
+  2. **Concurrency**: N concurrent transfers complete in ~1x transfer_delay,
+     not N× transfer_delay (proves tasks overlap on the event loop).
+
+Receiver property verified (PR #140 / async-pd-receiver):
+  3. **Non-blocking busy-wait**: when `allocate()` returns None (full buffer),
+     `_async_allocate_and_put` yields via `asyncio.sleep` so other coroutines
+     can run concurrently.  If `time.sleep` were used instead, a second
+     coroutine B would be blocked until A finishes its retries.
+"""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
+import threading
+import time
+
+# Third Party
+import msgspec
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObj,
+    PagedCpuGpuMemoryAllocator,
+)
+from lmcache.v1.storage_backend.pd_backend import (
+    AllocRequest,
+    AllocResponse,
+    PDBackend,
+    PDMsg,
+    ProxyNotif,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TRANSFER_DELAY = 0.15  # seconds – simulates a NIXL write taking 150 ms
+ALLOC_RETRY_DELAY = 0.02  # seconds – asyncio.sleep between alloc retries
+
+
+def _make_key(i: int) -> CacheEngineKey:
+    return CacheEngineKey(
+        model_name="test",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=i,
+        dtype=torch.bfloat16,
+    )
+
+
+def _make_mem_obj(idx: int = 0) -> MemoryObj:
+    """Create a minimal MemoryObj stub (no real GPU memory)."""
+    obj = MagicMock(spec=MemoryObj)
+    obj.meta = SimpleNamespace(
+        address=idx,
+        fmt=MemoryFormat.KV_2LTD,
+        shape=torch.Size([4, 2, 16, 8, 128]),
+        dtype=torch.bfloat16,
+    )
+    obj.get_ref_count.return_value = 1
+    return obj
+
+
+def _make_transfer_spec(
+    receiver_host="127.0.0.1",
+    init_port=9100,
+    alloc_port=9101,
+    req_id="req-0",
+    is_last_prefill=True,
+    num_transferred_tokens=0,
+):
+    return SimpleNamespace(
+        receiver_host=receiver_host,
+        receiver_init_port=[init_port],
+        receiver_alloc_port=[alloc_port],
+        req_id=req_id,
+        is_last_prefill=is_last_prefill,
+        num_transferred_tokens=num_transferred_tokens,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture: PDBackend sender with everything mocked out
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def async_sender(tmp_path):
+    """
+    Build a PDBackend in sender (prefiller) mode with:
+      - PagedCpuGpuMemoryAllocator mocked (no real GPU memory)
+      - get_zmq_context mocked (no real sockets)
+      - CreateTransferChannel mocked (async_batched_write sleeps TRANSFER_DELAY)
+      - ZMQ alloc socket mocked (returns a canned AllocResponse immediately)
+    """
+    # Third Party
+    import msgspec
+
+    # Use spec= so isinstance(mock, PagedCpuGpuMemoryAllocator) returns True.
+    mock_allocator_inst = MagicMock()
+    mock_allocator_inst.cpu_allocator.buffer_ptr = 0
+    mock_allocator_inst.cpu_allocator.buffer_size = 1024 * 1024 * 64
+    mock_allocator_inst.cpu_allocator.align_bytes = 1
+    # Make isinstance(mock, PagedCpuGpuMemoryAllocator) return True
+    mock_allocator_inst.__class__ = PagedCpuGpuMemoryAllocator
+
+    with (
+        patch("lmcache.v1.storage_backend.pd_backend.get_zmq_context") as mock_zmq_ctx,
+        patch("lmcache.v1.storage_backend.pd_backend.get_zmq_socket") as mock_zmq_sock,
+        patch(
+            "lmcache.v1.storage_backend.pd_backend.CreateTransferChannel"
+        ) as mock_create_tc,
+        patch(
+            "lmcache.v1.storage_backend.pd_backend.get_correct_device",
+            return_value="cpu",
+        ),
+    ):
+        # --- zmq context stub ---
+        mock_zmq_ctx.return_value = MagicMock()
+
+        # --- alloc socket stub: answers immediately with remote_indexes=[0] ---
+        alloc_socket = MagicMock()
+        alloc_response = AllocResponse(already_sent_indexes=[], remote_indexes=[0])
+        alloc_socket.recv = AsyncMock(
+            return_value=msgspec.msgpack.encode(alloc_response)
+        )
+        alloc_socket.send = AsyncMock()
+        mock_zmq_sock.return_value = alloc_socket
+
+        # --- transfer channel stub: async_batched_write sleeps TRANSFER_DELAY ---
+        tc = MagicMock()
+
+        async def _slow_write(*args, **kwargs):
+            await asyncio.sleep(TRANSFER_DELAY)
+            return 1
+
+        tc.async_batched_write = _slow_write
+        mock_create_tc.return_value = tc
+
+        # First Party
+        from lmcache.v1.config import LMCacheEngineConfig
+        from lmcache.v1.metadata import LMCacheMetadata
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=16,
+            pd_role="sender",
+            pd_proxy_host="127.0.0.1",
+            pd_proxy_port=5555,
+            pd_buffer_size=64 * 1024 * 1024,
+            pd_buffer_device="cpu",
+        )
+        metadata = LMCacheMetadata(
+            model_name="test",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 16, 8, 128),
+        )
+        backend = PDBackend(config, metadata)
+
+        # Replace proxy_side_channel with a dedicated mock so it doesn't
+        # share call history with the alloc socket mock.
+        backend.proxy_side_channel = MagicMock()
+
+        # Inject pre-connected peer so _ensure_peer_connection is a no-op
+        receiver_id = "127.0.0.1" + str(9100)
+        backend.initialized_peers.add(receiver_id)
+        # Inject async alloc socket directly (bypasses real ZMQ)
+        backend._async_alloc_sockets[receiver_id] = alloc_socket
+
+        yield backend
+
+        backend.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixture: PDBackend receiver with allocator mocked out
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def async_receiver(tmp_path):
+    """
+    Build a PDBackend in receiver (decoder) mode.
+    The ZMQ server socket is mocked so no real port is bound.
+    The memory allocator is mocked so we control when allocate() returns None.
+    """
+    # Use spec= so isinstance(mock, PagedCpuGpuMemoryAllocator) returns True.
+    mock_allocator_inst = MagicMock()
+    mock_allocator_inst.cpu_allocator.buffer_ptr = 0
+    mock_allocator_inst.cpu_allocator.buffer_size = 1024 * 1024 * 64
+    mock_allocator_inst.cpu_allocator.align_bytes = 1
+    # Make isinstance(mock, PagedCpuGpuMemoryAllocator) return True
+    mock_allocator_inst.__class__ = PagedCpuGpuMemoryAllocator
+
+    with (
+        patch("lmcache.v1.storage_backend.pd_backend.get_zmq_context") as mock_zmq_ctx,
+        patch("lmcache.v1.storage_backend.pd_backend.get_zmq_socket") as mock_zmq_sock,
+        patch(
+            "lmcache.v1.storage_backend.pd_backend.CreateTransferChannel"
+        ) as mock_create_tc,
+        patch(
+            "lmcache.v1.storage_backend.pd_backend.get_correct_device",
+            return_value="cpu",
+        ),
+    ):
+        mock_zmq_ctx.return_value = MagicMock()
+        mock_zmq_sock.return_value = MagicMock()
+        mock_create_tc.return_value = MagicMock()
+
+        # First Party
+        from lmcache.v1.config import LMCacheEngineConfig
+        from lmcache.v1.metadata import LMCacheMetadata
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=16,
+            pd_role="receiver",
+            pd_peer_host="127.0.0.1",
+            pd_peer_init_port=[9200],
+            pd_peer_alloc_port=[9201],
+            pd_buffer_size=64 * 1024 * 1024,
+            pd_buffer_device="cpu",
+        )
+        metadata = LMCacheMetadata(
+            model_name="test",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 16, 8, 128),
+        )
+        backend = PDBackend(config, metadata)
+        yield backend
+        backend.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Fire-and-forget — function returns before transfer completes
+# ---------------------------------------------------------------------------
+
+
+def test_sender_returns_before_transfer_completes(async_sender):
+    """
+    batched_submit_put_task() must return BEFORE async_batched_write finishes.
+
+    We measure the wall time of the call. If it takes >= TRANSFER_DELAY the
+    call is blocking (bad). If it returns in << TRANSFER_DELAY it's truly
+    fire-and-forget (good).
+    """
+    keys = [_make_key(0)]
+    memory_objs = [_make_mem_obj(0)]
+    transfer_spec = _make_transfer_spec()
+
+    t0 = time.monotonic()
+    async_sender.batched_submit_put_task(keys, memory_objs, transfer_spec=transfer_spec)
+    elapsed = time.monotonic() - t0
+
+    # Should return in << TRANSFER_DELAY
+    # (allow up to 50% of delay for scheduling overhead)
+    assert elapsed < TRANSFER_DELAY * 0.5, (
+        f"batched_submit_put_task took {elapsed:.3f}s — looks like it's still blocking "
+        f"(expected < {TRANSFER_DELAY * 0.5:.3f}s)"
+    )
+
+    # Give the background task time to finish so we don't leave dangling tasks
+    time.sleep(TRANSFER_DELAY * 1.5)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Concurrency — N tasks complete in ≈ 1× delay, not N×
+# ---------------------------------------------------------------------------
+
+
+def test_sender_transfers_are_concurrent(async_sender):
+    """
+    Submit N transfers simultaneously. If async works correctly, they run
+    concurrently on the event loop and finish in ≈ TRANSFER_DELAY total,
+    not N × TRANSFER_DELAY.
+    """
+    N = 4
+    done_events = [threading.Event() for _ in range(N)]
+
+    def make_callback(i):
+        def cb(key):
+            done_events[i].set()
+
+        return cb
+
+    t0 = time.monotonic()
+    for i in range(N):
+        keys = [_make_key(i)]
+        memory_objs = [_make_mem_obj(i)]
+        spec = _make_transfer_spec(req_id=f"req-{i}")
+        async_sender.batched_submit_put_task(
+            keys,
+            memory_objs,
+            transfer_spec=spec,
+            on_complete_callback=make_callback(i),
+        )
+
+    # Wait for all to complete
+    for ev in done_events:
+        finished = ev.wait(timeout=TRANSFER_DELAY * 3)
+        assert finished, (
+            "Transfer did not complete within timeout — event loop may be stalled"
+        )
+
+    total_elapsed = time.monotonic() - t0
+
+    # With true concurrency: total ≈ TRANSFER_DELAY
+    # With sequential execution: total ≈ N × TRANSFER_DELAY
+    max_allowed = TRANSFER_DELAY * 1.8  # allow 80% overhead
+    assert total_elapsed < max_allowed, (
+        f"{N} transfers took {total_elapsed:.3f}s, expected < {max_allowed:.3f}s."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Receiver busy-wait is non-blocking
+# ---------------------------------------------------------------------------
+
+
+def test_receiver_alloc_busy_wait_is_non_blocking(async_receiver):
+    """
+    Prove that the *real* _async_allocate_and_put uses asyncio.sleep (not
+    time.sleep) when allocate() returns None.
+
+    Two AllocRequests run concurrently via asyncio.gather:
+      - req_a: allocate() returns None for RETRY_COUNT calls (per task),
+               then succeeds. The real busy-wait loop fires RETRY_COUNT times.
+      - req_b: allocate() succeeds immediately.
+
+    We use asyncio.current_task() inside patched allocate() to distinguish
+    which coroutine is calling, so retry counts are tracked per-task.
+
+    If asyncio.sleep is used (correct):
+        req_b runs while req_a is yielding → finish_order == ["b", "a"].
+    If time.sleep is used (blocking):
+        req_b cannot run until req_a finishes → finish_order == ["a", "b"].
+    """
+    RETRY_COUNT = 5
+
+    key_a = _make_key(100)
+    key_b = _make_key(200)
+    mem_obj_a = _make_mem_obj(idx=10)
+    mem_obj_b = _make_mem_obj(idx=20)
+
+    finish_order: list[str] = []
+
+    # Wrap put() to record store order
+    original_put = async_receiver.put
+
+    def tracked_put(key, mem_obj):
+        if key == key_a:
+            finish_order.append("a")
+        elif key == key_b:
+            finish_order.append("b")
+        return original_put(key, mem_obj)
+
+    async_receiver.put = tracked_put
+
+    # Patch allocate() to use asyncio.current_task() as per-coroutine context.
+    # Each task tracks its own call count independently.
+    task_alloc_calls: dict[int, int] = {}
+
+    def patched_allocate(shapes, dtype, fmt=MemoryFormat.KV_2LTD, **kwargs):
+        task = asyncio.current_task()
+        task_id = id(task)
+        task_alloc_calls[task_id] = task_alloc_calls.get(task_id, 0) + 1
+        n = task_alloc_calls[task_id]
+        # The task handling key_a was submitted first (call n=1 initially);
+        # distinguish by whether this task has already been seen before the
+        # *other* task's first call. Use a simple heuristic: first task to
+        # call allocate is A (gets retries), second is B (immediate success).
+        if task_id not in _task_roles:
+            _task_roles[task_id] = "a" if len(_task_roles) == 0 else "b"
+        role = _task_roles[task_id]
+        if role == "a" and n <= RETRY_COUNT:
+            return None
+        return mem_obj_a if role == "a" else mem_obj_b
+
+    _task_roles: dict[int, str] = {}
+    async_receiver.allocate = patched_allocate
+
+    alloc_req_a = AllocRequest(
+        keys=[key_a.to_string()],
+        fmt=MemoryFormat.KV_2LTD.value,
+        shape=[4, 2, 16, 8, 128],
+        dtype="bfloat16",
+        last_chunk_toks=16,
+    )
+    alloc_req_b = AllocRequest(
+        keys=[key_b.to_string()],
+        fmt=MemoryFormat.KV_2LTD.value,
+        shape=[4, 2, 16, 8, 128],
+        dtype="bfloat16",
+        last_chunk_toks=16,
+    )
+
+    async def run_concurrent():
+        await asyncio.gather(
+            async_receiver._async_allocate_and_put(alloc_req_a),
+            async_receiver._async_allocate_and_put(alloc_req_b),
+        )
+
+    asyncio.run(run_concurrent())
+
+    assert finish_order == ["b", "a"], (
+        f"Expected finish order ['b', 'a'] but got {finish_order}. "
+        "This suggests _async_allocate_and_put uses time.sleep (blocking) "
+        "instead of asyncio.sleep (non-blocking): req_b could not run while "
+        "req_a was busy-waiting for memory."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Proxy notification sent on last prefill
+# ---------------------------------------------------------------------------
+
+
+def test_sender_proxy_notification_on_last_prefill(async_sender):
+    """
+    When transfer_spec.is_last_prefill is True, the sender must send a
+    ProxyNotif message to proxy_side_channel after transfer completes.
+    """
+    keys = [_make_key(0)]
+    memory_objs = [_make_mem_obj(0)]
+    transfer_spec = _make_transfer_spec(is_last_prefill=True, req_id="req-notify")
+
+    done = threading.Event()
+
+    def cb(key):
+        done.set()
+
+    async_sender.batched_submit_put_task(
+        keys, memory_objs, transfer_spec=transfer_spec, on_complete_callback=cb
+    )
+
+    assert done.wait(timeout=TRANSFER_DELAY * 3), "Transfer did not complete"
+
+    # Verify proxy notification was sent
+    async_sender.proxy_side_channel.send.assert_called_once()
+    sent_bytes = async_sender.proxy_side_channel.send.call_args[0][0]
+    notif = msgspec.msgpack.decode(sent_bytes, type=PDMsg)
+    assert isinstance(notif, ProxyNotif)
+    assert notif.req_id == "req-notify"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: No proxy notification when not last prefill
+# ---------------------------------------------------------------------------
+
+
+def test_sender_no_proxy_notification_when_not_last_prefill(async_sender):
+    """
+    When transfer_spec.is_last_prefill is False, no ProxyNotif should be sent.
+    """
+    keys = [_make_key(0)]
+    memory_objs = [_make_mem_obj(0)]
+    transfer_spec = _make_transfer_spec(is_last_prefill=False)
+
+    done = threading.Event()
+    async_sender.batched_submit_put_task(
+        keys,
+        memory_objs,
+        transfer_spec=transfer_spec,
+        on_complete_callback=lambda k: done.set(),
+    )
+
+    assert done.wait(timeout=TRANSFER_DELAY * 3)
+    async_sender.proxy_side_channel.send.assert_not_called()


### PR DESCRIPTION
**What this PR does / why we need it**:

`proxy_side_channel.send()` inside `_async_transfer_task` is a synchronous ZMQ `PUSH` send running inside an async coroutine on the sender event loop. Although ZMQ `PUSH` send is usually fast (buffered), it *can* block briefly under back-pressure and will always acquire the GIL, momentarily stalling other concurrent transfer coroutines sharing the same loop.

This PR wraps the call with `loop.run_in_executor(None, ...)` to offload it to the default thread pool executor, keeping the event loop fully responsive.

**Changes:**
- `pd_backend.py`: Replace `self.proxy_side_channel.send(notif_msg_bytes)` with `await loop.run_in_executor(None, self.proxy_side_channel.send, notif_msg_bytes)`

**Risk:** Minimal — `run_in_executor` with the default executor is a well-established asyncio pattern. The existing proxy notification tests (Test 4 & 5) still pass.

Depends on: #145