### PR TITLE
fix(pd_backend): send ProxyNotif before on_complete_callback

### DIFF
--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -468,6 +468,13 @@ class PDBackend(AllocatorBackendInterface):
                     " Skipping transfer."
                 )
 
+            if transfer_spec is not None and getattr(
+                transfer_spec, "is_last_prefill", False
+            ):
+                notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
+                notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
+                self.proxy_side_channel.send(notif_msg_bytes)
+
             if on_complete_callback is not None:
                 for key in keys:
                     try:
@@ -476,13 +483,6 @@ class PDBackend(AllocatorBackendInterface):
                         logger.warning(
                             f"on_complete_callback failed for key {key}: {e}"
                         )
-
-            if transfer_spec is not None and getattr(
-                transfer_spec, "is_last_prefill", False
-            ):
-                notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
-                notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
-                self.proxy_side_channel.send(notif_msg_bytes)
         except Exception as e:
             logger.error("Async transfer task failed: %s", str(e))
             # Release ref counts on error to avoid leaks (only those not yet released)


### PR DESCRIPTION
**What this PR does / why we need it**:

Reorders `_async_transfer_task` so that `ProxyNotif` is sent **before** `on_complete_callback` is invoked.

**Why:**

```
# Before (wrong order):
on_complete_callback(key)     # ← caller sees 'done'
proxy_side_channel.send(...)  # ← but proxy hasn't been notified yet

# After (correct order):
proxy_side_channel.send(...)  # ← proxy notified (decode can start)
on_complete_callback(key)     # ← now caller sees 'done'
```

The proxy notification is part of the transfer completion semantics — it tells the proxy that KV data has landed on the receiver and decode can begin. The `on_complete_callback` is a caller-level hook that should fire after **all** transfer-related work is done, including proxy notification.

With the previous ordering, any code that waits on the callback and then checks proxy state (e.g. unit tests, or future monitoring hooks) would race against the notification send.

**Changes:** Pure reorder, no logic change. 7 lines moved up, 7 lines moved down.

Depends on: #145