### PR TITLE
[refactor] reserve zero-copy buffer allocation interface to NonGpuContext for shm solution

### DIFF
--- a/docs/design/v1/multiprocess/non_gpu_context_design.md
+++ b/docs/design/v1/multiprocess/non_gpu_context_design.md
@@ -37,7 +37,7 @@ polymorphic `TransferContext` abstraction.
 | Transport | Copies | Data flow |
 |---|---|---|
 | CUDA IPC | 2 | GPU KV → GPU staging buffer → CPU memory obj |
-| Pickle | 4 | GPU KV → CPU chunk → pickle.dumps → pickle.loads → CPU memory obj |
+| Pickle | 3 | GPU KV → CPU chunk → pickle.dumps → (MQ send) → pickle.loads → CPU memory obj |
 | SHM (TODO) | 1 | GPU KV → CPU memory obj (SHM mapped) |
 
 **Retrieve (server storage → worker):**
@@ -45,7 +45,7 @@ polymorphic `TransferContext` abstraction.
 | Transport | Copies | Data flow |
 |---|---|---|
 | CUDA IPC | 2 | CPU memory obj → GPU staging buffer → GPU KV |
-| Pickle | 4 | CPU memory obj → pickle.dumps → pickle.loads → CPU chunk → GPU KV |
+| Pickle | 3 | CPU memory obj → (MQ send) → pickle.loads → CPU chunk → GPU KV |
 | SHM (TODO) | 1 | CPU memory obj (SHM mapped) → GPU KV |
 
 **Applicability:**
@@ -53,7 +53,7 @@ polymorphic `TransferContext` abstraction.
 | Transport | Platform requirement | Pros | Cons |
 |---|---|---|---|
 | CUDA IPC | NVIDIA CUDA devices only | Async GPU streams, mature path | CUDA-only |
-| Pickle | Any device, no dependencies | Generally available, zero setup | 4 copies + serialisation overhead |
+| Pickle | Any device, no dependencies | Generally available, zero setup | 3 copies + serialisation overhead, one-way data size = KV size |
 | SHM (TODO) | `/dev/shm` capacity ≥ L1 cache size | Fewest copies (1), no serialisation | Requires sufficient shared memory |
 
 ## 2. Architecture Overview
@@ -65,7 +65,7 @@ vllm_multi_process_adapter.py    ← Engine adapter, device-agnostic
   └── TransferContext             ← Worker-side transport abstraction (§3)
         ├── CudaTransferContext    ← CUDA IPC + MQ future path
         └── NonCudaTransferContext     ← Synchronous gather/scatter path
-              └── NonGpuContext        ← Serialisation abstraction (§4.2)
+              └── NonGpuContext        ← Serialisation abstraction (§4)
                     ├── NonGpuContextPickle   ← pickle.dumps/loads (§4.3)
                     └── NonGpuContextShm      ← shared memory (§4.4, TODO)
 ```
@@ -74,7 +74,7 @@ Two layers of abstraction serve different purposes:
 
 - **TransferContext** (§3) — decides **CUDA vs non-CUDA** routing at the
   worker adapter level.
-- **NonGpuContext** (§4.2) — decides **how** CPU chunk data is serialised and
+- **NonGpuContext** (§4) — decides **how** CPU chunk data is serialised and
   transported (pickle vs SHM). Only used inside `NonCudaTransferContext`.
 
 ### 2.2 State machine (worker ↔ server)
@@ -107,22 +107,19 @@ Two layers of abstraction serve different purposes:
                      |                                 |
                      v                                 v
            STORE (GPU → L1)            gather_paged_kv_to_cpu()
-           [async MQ future]           + _non_gpu_context.prepare_store()
-                     |                 + _non_gpu_context.commit_store() [sync]
-                     v                         _store_done[id] = ok
+           [async MQ future]           + prepare_store()  → PREPARE_STORE
+                                          + commit_store() → COMMIT_STORE (pickled bytes)
+                                          ✓ _store_done[id] = ok
                  [READY]                               |
                      +----------------+----------------+
                                       |
                                       v
-      transfer_ctx.submit_retrieve()  +  poll_finished()
-                                      |
-                     +----------------+----------------+
-                     |                                 |
-                     v                                 v
-          RETRIEVE (L1 → GPU)     _non_gpu_context.prepare_retrieve() [sync]
-          [async MQ future]       + scatter_cpu_to_paged_kv()
-                     |            + _non_gpu_context.commit_retrieve()
-                     v            _retrieve_done[id] = (ok, block_ids)
+      transfer_ctx.submit_retrieve()  + prepare_retrieve() → PREPARE_RETRIEVE
+                                      |    (server returns pickled bytes)
+                                      v    
+          RETRIEVE (L1 → GPU)          + scatter_cpu_to_paged_kv()
+          [async MQ future]                 + commit_retrieve() → COMMIT_RETRIEVE
+                                          ✓ _retrieve_done[id] = (ok, block_ids)
                      +----------------+----------------+
                                       |
                                       v
@@ -174,38 +171,76 @@ are **synchronous**: gather → prepare/commit, then record result in
 
 ## 4. Server-side: Non-GPU Context Protocol
 
-### 4.1 Why GPU context and non-GPU context need different protocols
+### 4.1 Five new protocol messages
 
-| | GPU context | non-GPU context |
-|---|---|---|
-| Registration | `REGISTER_KV_CACHE` — IPC handles | `REGISTER_KV_CACHE_NON_GPU_CONTEXT` — scalar fields |
-| Store | `STORE` — event handle + block IDs, server reads GPU directly | `STORE_CPU_CHUNKS` — serialised CPU tensors |
-| Retrieve | `RETRIEVE` — event handle + block IDs, server writes GPU directly | `RETRIEVE_CPU_CHUNKS` — key lookup, returns CPU tensors |
+The non-GPU context path introduces five new messages for two-phase store/retrieve:
 
-Registration uses **scalar fields** (`block_size`, `num_layers`,
-`hidden_dim_size`, `dtype_str`, `use_mla`) instead of pickled objects
-to avoid cross-process pickle security and compatibility concerns. The
-server reconstructs `MemoryLayoutDesc` from the scalars internally.
+| Message | Payload | Response | Description |
+|---------|---------|----------|-------------|
+| `REGISTER_KV_CACHE_NON_GPU_CONTEXT` | `RegisterNonGpuContextPayload` (scalar metadata) | None | Register with scalar fields instead of IPC handles |
+| `PREPARE_STORE` | `key, instance_id` | `PrepareStoreResponse(context: dict)` | Allocate resources, returns slot info |
+| `COMMIT_STORE` | `key, instance_id, cpu_data: bytes` ` | `bool` | Send serialised data |
+| `PREPARE_RETRIEVE` | `key, instance_id` | `PrepareRetrieveResponse(success, data: bytes, context: dict)` | Lookup key, return data |
+| `COMMIT_RETRIEVE` | `key, instance_id` | `bool` | Release locks/resources |
 
-### 4.2 `NonGpuContext` ABC: two-phase prepare/commit
+### 4.2 Why new messages needed
 
-The serialisation layer is abstracted behind `NonGpuContext` so that pickle
-and SHM can be swapped without touching `NonCudaTransferContext` or the server.
+| GPU context | non-GPU context |
+|---|---|
+| Uses `REGISTER_KV_CACHE` with IPC handles | Uses `REGISTER_KV_CACHE_NON_GPU_CONTEXT` with scalar fields |
+| Single `STORE` message with IPC handle | Two-phase: `PREPARE_STORE` + `COMMIT_STORE` |
+| Single `RETRIEVE` message with IPC handle | Two-phase: `PREPARE_RETRIEVE` + `COMMIT_RETRIEVE` |
 
-The ABC defines: `prepare_store`, `commit_store`, `prepare_retrieve`,
-`commit_retrieve`, `close`.
+Why scalar fields for registration? To avoid cross-process pickle security
+and compatibility concerns. The server reconstructs `MemoryLayoutDesc` from
+the scalars internally.
 
-Why two phases? Pickle can do everything in one step (prepare serialises,
-commit sends). SHM needs prepare to allocate a slot, then the worker writes
-into mapped memory, then commit tells the server "ready". The split
-accommodates both without forcing unnecessary round-trips on pickle.
+Two-phase design: Pickle can technically do everything in one step, but
+SHM needs prepare to allocate a slot, then worker writes to mapped memory,
+then commit tells server "ready". The split accommodates both without forcing
+unnecessary round-trips on pickle.
 
-| Phase | Pickle | SHM (TODO) |
-|---|---|---|
-| `prepare_store` | `pickle.dumps(chunks)` → opaque handle | MQ `PREPARE_STORE` → get SHM offset → `memcpy` into SHM |
-| `commit_store` | MQ `STORE_CPU_CHUNKS`, block for ack | MQ `COMMIT_STORE` → server reads from SHM |
-| `prepare_retrieve` | MQ `RETRIEVE_CPU_CHUNKS` → `pickle.loads` | MQ `PREPARE_RETRIEVE` → server writes to SHM → map tensor views |
-| `commit_retrieve` | no-op | MQ `FINISH_READ` → release SHM read lock |
+### 4.3 `NonGpuContext` ABC
+
+Abstract base class for serialisation implementations:
+
+```python
+class NonGpuContext(ABC):
+    def prepare_store(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
+        """Send PREPARE_STORE, allocate resources. Returns pre-allocated buffers or None."""
+
+    def commit_store(self, key: Any, instance_id: int, chunks: list[torch.Tensor]) -> bool:
+        """Send COMMIT_STORE with serialised data. Returns success."""
+
+    def prepare_retrieve(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
+        """Send PREPARE_RETRIEVE, deserialise response. Returns chunks or None."""
+
+    def commit_retrieve(self, key: Any, instance_id: int) -> bool:
+        """Send COMMIT_RETRIEVE for cleanup. Returns success."""
+
+    def allocate_store_buffers(self, size: int) -> list[torch.Tensor] | None:
+        """Allocate SHM buffers for store. Default: None (for pickle)."""
+
+    def allocate_retrieve_buffers(self, size: int) -> list[torch.Tensor] | None:
+        """Allocate SHM buffers for retrieve. Default: None (for pickle)."""
+
+    def close(self) -> None:
+        """Release resources."""
+```
+
+### 4.4 Implementation variants
+
+**Pickle (`NonGpuContextPickle`):**
+- `prepare_store`: sends `PREPARE_STORE`, returns `None` (no pre-allocated buffers)
+- `commit_store`: `pickle.dumps(chunks)` → sends via `COMMIT_STORE`
+- `prepare_retrieve`: sends `PREPARE_RETRIEVE`, `pickle.loads(response.data)`
+- `commit_retrieve`: sends `COMMIT_RETRIEVE` (no-op for pickle)
+
+**SHM (`NonGpuContextShm`) — TODO:**
+- `prepare_store`: allocate SHM slot, return slot info in context
+- `commit_store`: confirm write, server reads from SHM
+- `prepare_retrieve`: server writes to SHM, return slot info
+- `commit_retrieve`: release SHM read lock
 
 `create_non_gpu_context()` factory currently always returns `NonGpuContextPickle`.
 Future: probe `/dev/shm` availability and capacity, fall back to pickle if
@@ -241,92 +276,11 @@ rather than per-token `index_select` / `index_copy_`. For HND layouts, a
 - **`compute_kv_layout`** — extracts `(block_size, num_layers, hidden_dim_size, dtype_str, gpu_kv_format)` from live KV tensors.
 - **`gather_paged_kv_to_cpu`** — gathers paged blocks into CPU chunk tensors.
 - **`scatter_cpu_to_paged_kv`** — scatters CPU chunks back into device paged KV tensors. Respects `skip_first_n_tokens` for partial-prefix retrieval.
-
-## 5. Five New Protocol Messages
-
-The non-GPU context path introduces five new messages for two-phase store/retrieve:
-
-| Message | Direction | Payload | Response | Pickle Usage | SHM Usage (TODO) |
-|---------|-----------|---------|----------|--------------|------------------|
-| `REGISTER_KV_CACHE_NON_GPU_CONTEXT` | Worker→Server | `RegisterNonGpuContextPayload` (scalar metadata: block_size, num_layers, hidden_dim_size, dtype_str, use_mla) | None | Sends scalar metadata | Sends scalar metadata |
-| `PREPARE_STORE` | Worker→Server | `key, instance_id` | `PrepareStoreResponse(context={})` | Returns empty slots | Returns SHM slot info |
-| `COMMIT_STORE` | Worker→Server | `key, instance_id, cpu_data: bytes` | `bool` | `pickle.dumps(chunks)` → sends bytes | Confirms write, releases slot |
-| `PREPARE_RETRIEVE` | Worker→Server | `key, instance_id` | `PrepareRetrieveResponse(success, data: bytes, context)` | Server returns `pickle.dumps(chunks)` | Returns SHM slot info |
-| `COMMIT_RETRIEVE` | Worker→Server | `key, instance_id` | `bool` | No-op | Releases SHM read lock |
-
-### Message signatures
-
-```python
-# From protocols/engine.py
-PREPARE_STORE:   (KeyType, int) → PrepareStoreResponse(context: dict)
-COMMIT_STORE:    (KeyType, int, bytes) → bool
-PREPARE_RETRIEVE: (KeyType, int) → PrepareRetrieveResponse(success, data: bytes, context: dict)
-COMMIT_RETRIEVE: (KeyType, int) → bool
-```
-
-### Pickle path flow
-
-```
-Store:
-  worker: gather_paged_kv_to_cpu()
-  worker: prepare_store()    → PREPARE_STORE
-  worker: pickle.dumps(chunks) → COMMIT_STORE (payload: bytes)
-  server: pickle.loads() → write to memory
-
-Retrieve:
-  worker: prepare_retrieve() → PREPARE_RETRIEVE
-  server: pickle.dumps(chunks) → response.data
-  worker: pickle.loads() → chunks → scatter_cpu_to_paged_kv()
-  worker: commit_retrieve() → COMMIT_RETRIEVE (no-op)
-```
-
-### SHM path flow (TODO)
-
-```
-Store:
-  worker: prepare_store() → PREPARE_STORE
-  server: allocate SHM slot → return context={slot_id: xxx}
-  worker: memcpy to SHM (via mapped memory)
-  worker: commit_store() → COMMIT_STORE (confirmation)
-  server: read from SHM → free slot
-
-Retrieve:
-  worker: prepare_retrieve() → PREPARE_RETRIEVE
-  server: write data to SHM → return context={slot_id: xxx}
-  worker: read from SHM (via mapped memory) → scatter to GPU
-  worker: commit_retrieve() → COMMIT_RETRIEVE (release lock)
-```
+- **`gather_paged_kv_to_cpu(out=...)`** — writes directly into pre-allocated buffers (for SHM zero-copy).
 
 ## 6. SHM Implementation Details (TODO)
 
-### 6.1 NonGpuContext ABC extensions
-
-```python
-class NonGpuContext(ABC):
-    def prepare_store(self, key, instance_id) -> list[torch.Tensor] | None:
-        """Allocate store buffers. Returns pre-allocated buffers or None."""
-        ...
-
-    def allocate_store_buffers(self, size: int) -> list[torch.Tensor] | None:
-        """Allocate shared memory buffers for store. Default: None."""
-        return None
-
-    def commit_store(self, key, instance_id, chunks) -> bool:
-        ...
-
-    def prepare_retrieve(self, key, instance_id) -> list[torch.Tensor] | None:
-        """Get retrieve buffers. For SHM, returns data from shared memory."""
-        ...
-
-    def allocate_retrieve_buffers(self, size: int) -> list[torch.Tensor] | None:
-        """Allocate shared memory buffers for retrieve. Default: None."""
-        return None
-
-    def commit_retrieve(self, key, instance_id) -> bool:
-        ...
-```
-
-### 6.2 SHM fallback conditions
+### 6.1 SHM fallback conditions
 
 SHM is the **optimal** transport with only **1 copy**, but requires:
 
@@ -334,6 +288,27 @@ SHM is the **optimal** transport with only **1 copy**, but requires:
 - `/dev/shm` capacity ≥ L1 cache size (`worker_l1_cached_chunks * chunk_size_bytes`)
 
 If conditions are not met, automatically fall back to **Pickle** (3 copies).
+
+### 6.2 Zero-copy path with `out=` parameter
+
+The `gather_paged_kv_to_cpu` function accepts an optional `out` parameter:
+
+```python
+def gather_paged_kv_to_cpu(
+    kv_caches: dict[str, torch.Tensor],
+    layout: MemoryLayoutDesc,
+    block_ids: list[int],
+    out: list[torch.Tensor] | None = None,
+) -> list[torch.Tensor]:
+    if out is not None:
+        for chunk, buf in zip(chunks, out, strict=False):
+            buf.copy_(chunk, non_blocking=True)
+        return out
+    return chunks
+```
+
+This enables SHM implementations to pre-allocate shared memory buffers and
+write directly into them, avoiding an extra copy.
 
 ### 6.3 TODO items
 

--- a/docs/design/v1/multiprocess/non_gpu_context_design.md
+++ b/docs/design/v1/multiprocess/non_gpu_context_design.md
@@ -242,6 +242,107 @@ rather than per-token `index_select` / `index_copy_`. For HND layouts, a
 - **`gather_paged_kv_to_cpu`** — gathers paged blocks into CPU chunk tensors.
 - **`scatter_cpu_to_paged_kv`** — scatters CPU chunks back into device paged KV tensors. Respects `skip_first_n_tokens` for partial-prefix retrieval.
 
+## 5. Five New Protocol Messages
+
+The non-GPU context path introduces five new messages for two-phase store/retrieve:
+
+| Message | Direction | Payload | Response | Pickle Usage | SHM Usage (TODO) |
+|---------|-----------|---------|----------|--------------|------------------|
+| `REGISTER_KV_CACHE_NON_GPU_CONTEXT` | Worker→Server | `RegisterNonGpuContextPayload` (scalar metadata: block_size, num_layers, hidden_dim_size, dtype_str, use_mla) | None | Sends scalar metadata | Sends scalar metadata |
+| `PREPARE_STORE` | Worker→Server | `key, instance_id` | `PrepareStoreResponse(context={})` | Returns empty slots | Returns SHM slot info |
+| `COMMIT_STORE` | Worker→Server | `key, instance_id, cpu_data: bytes` | `bool` | `pickle.dumps(chunks)` → sends bytes | Confirms write, releases slot |
+| `PREPARE_RETRIEVE` | Worker→Server | `key, instance_id` | `PrepareRetrieveResponse(success, data: bytes, context)` | Server returns `pickle.dumps(chunks)` | Returns SHM slot info |
+| `COMMIT_RETRIEVE` | Worker→Server | `key, instance_id` | `bool` | No-op | Releases SHM read lock |
+
+### Message signatures
+
+```python
+# From protocols/engine.py
+PREPARE_STORE:   (KeyType, int) → PrepareStoreResponse(context: dict)
+COMMIT_STORE:    (KeyType, int, bytes) → bool
+PREPARE_RETRIEVE: (KeyType, int) → PrepareRetrieveResponse(success, data: bytes, context: dict)
+COMMIT_RETRIEVE: (KeyType, int) → bool
+```
+
+### Pickle path flow
+
+```
+Store:
+  worker: gather_paged_kv_to_cpu()
+  worker: prepare_store()    → PREPARE_STORE
+  worker: pickle.dumps(chunks) → COMMIT_STORE (payload: bytes)
+  server: pickle.loads() → write to memory
+
+Retrieve:
+  worker: prepare_retrieve() → PREPARE_RETRIEVE
+  server: pickle.dumps(chunks) → response.data
+  worker: pickle.loads() → chunks → scatter_cpu_to_paged_kv()
+  worker: commit_retrieve() → COMMIT_RETRIEVE (no-op)
+```
+
+### SHM path flow (TODO)
+
+```
+Store:
+  worker: prepare_store() → PREPARE_STORE
+  server: allocate SHM slot → return context={slot_id: xxx}
+  worker: memcpy to SHM (via mapped memory)
+  worker: commit_store() → COMMIT_STORE (confirmation)
+  server: read from SHM → free slot
+
+Retrieve:
+  worker: prepare_retrieve() → PREPARE_RETRIEVE
+  server: write data to SHM → return context={slot_id: xxx}
+  worker: read from SHM (via mapped memory) → scatter to GPU
+  worker: commit_retrieve() → COMMIT_RETRIEVE (release lock)
+```
+
+## 6. SHM Implementation Details (TODO)
+
+### 6.1 NonGpuContext ABC extensions
+
+```python
+class NonGpuContext(ABC):
+    def prepare_store(self, key, instance_id) -> list[torch.Tensor] | None:
+        """Allocate store buffers. Returns pre-allocated buffers or None."""
+        ...
+
+    def allocate_store_buffers(self, size: int) -> list[torch.Tensor] | None:
+        """Allocate shared memory buffers for store. Default: None."""
+        return None
+
+    def commit_store(self, key, instance_id, chunks) -> bool:
+        ...
+
+    def prepare_retrieve(self, key, instance_id) -> list[torch.Tensor] | None:
+        """Get retrieve buffers. For SHM, returns data from shared memory."""
+        ...
+
+    def allocate_retrieve_buffers(self, size: int) -> list[torch.Tensor] | None:
+        """Allocate shared memory buffers for retrieve. Default: None."""
+        return None
+
+    def commit_retrieve(self, key, instance_id) -> bool:
+        ...
+```
+
+### 6.2 SHM fallback conditions
+
+SHM is the **optimal** transport with only **1 copy**, but requires:
+
+- `/dev/shm` must exist and be writable
+- `/dev/shm` capacity ≥ L1 cache size (`worker_l1_cached_chunks * chunk_size_bytes`)
+
+If conditions are not met, automatically fall back to **Pickle** (3 copies).
+
+### 6.3 TODO items
+
+- [ ] Implement `NonGpuContextShm` class
+- [ ] Implement SHM slot allocation / lifecycle management
+- [ ] Add `/dev/shm` capacity check in `create_non_gpu_context()`
+- [ ] Implement async SHM read/write with proper locking
+- [ ] Add error handling and auto-fallback to Pickle
+
 ## Non-goals
 
 - No change to existing CUDA IPC path semantics.

--- a/lmcache/v1/multiprocess/non_gpu_context.py
+++ b/lmcache/v1/multiprocess/non_gpu_context.py
@@ -69,61 +69,25 @@ class NonGpuContext(ABC):
         return self.metadata.layout_desc
 
     @abstractmethod
-    def prepare_store(
-        self, key: Any, instance_id: int, block_ids: list[int], blocks_per_chunk: int
-    ) -> tuple[Any, list[torch.Tensor] | None]:
-        """Prepare a store operation.
-
-        Args:
-            key: Cache key for the token range to store.
-            instance_id: Worker instance identifier.
-            block_ids: Block IDs to store.
-            blocks_per_chunk: Number of blocks per chunk.
-
-        Returns:
-            A ``(handle, out_buffers)`` pair. ``out_buffers`` is a list of
-            pre-allocated CPU tensors for gather to write into, or ``None``
-            if gather should allocate its own.
-        """
+    def prepare_store(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
+        """Prepare store. Returns pre-allocated out buffers (shm) or None (pickle)."""
         ...
 
     @abstractmethod
-    def commit_store(self, handle: Any, chunks: list[torch.Tensor]) -> bool:
-        """Commit a prepared store operation.
-
-        Args:
-            handle: The opaque handle returned by :meth:`prepare_store`.
-            chunks: CPU chunk tensors to store.
-
-        Returns:
-            ``True`` on success, ``False`` otherwise.
-        """
+    def commit_store(
+        self, key: Any, instance_id: int, chunks: list[torch.Tensor]
+    ) -> bool:
+        """Commit store. Pickle: serialize and send. Shm: notify server."""
         ...
 
     @abstractmethod
-    def prepare_retrieve(
-        self, key: Any, instance_id: int
-    ) -> tuple[Any, list[torch.Tensor] | None]:
-        """Prepare a retrieve operation.
-
-        Args:
-            key: Cache key for the token range to retrieve.
-            instance_id: Worker instance identifier.
-
-        Returns:
-            A ``(handle, chunks)`` pair. ``chunks`` is a list of CPU tensors
-            on cache hit, or ``None`` on cache miss. The handle must be
-            passed to :meth:`commit_retrieve`.
-        """
+    def prepare_retrieve(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
+        """Prepare retrieve. Returns chunks or shm views, or None on miss."""
         ...
 
     @abstractmethod
-    def commit_retrieve(self, handle: Any) -> None:
-        """Finalise a retrieve operation (release locks, cleanup, etc.).
-
-        Args:
-            handle: The opaque handle returned by :meth:`prepare_retrieve`.
-        """
+    def commit_retrieve(self, key: Any, instance_id: int) -> bool:
+        """Commit retrieve. Pickle: no-op. Shm: release read locks."""
         ...
 
     @abstractmethod

--- a/lmcache/v1/multiprocess/non_gpu_context.py
+++ b/lmcache/v1/multiprocess/non_gpu_context.py
@@ -70,26 +70,30 @@ class NonGpuContext(ABC):
 
     @abstractmethod
     def prepare_store(
-        self, key: Any, instance_id: int, chunks: list[torch.Tensor]
-    ) -> Any:
+        self, key: Any, instance_id: int, block_ids: list[int], blocks_per_chunk: int
+    ) -> tuple[Any, list[torch.Tensor] | None]:
         """Prepare a store operation.
 
         Args:
             key: Cache key for the token range to store.
             instance_id: Worker instance identifier.
-            chunks: CPU chunk tensors to store.
+            block_ids: Block IDs to store.
+            blocks_per_chunk: Number of blocks per chunk.
 
         Returns:
-            An opaque handle to be passed to :meth:`commit_store`.
+            A ``(handle, out_buffers)`` pair. ``out_buffers`` is a list of
+            pre-allocated CPU tensors for gather to write into, or ``None``
+            if gather should allocate its own.
         """
         ...
 
     @abstractmethod
-    def commit_store(self, handle: Any) -> bool:
+    def commit_store(self, handle: Any, chunks: list[torch.Tensor]) -> bool:
         """Commit a prepared store operation.
 
         Args:
             handle: The opaque handle returned by :meth:`prepare_store`.
+            chunks: CPU chunk tensors to store.
 
         Returns:
             ``True`` on success, ``False`` otherwise.
@@ -203,6 +207,7 @@ def gather_paged_kv_to_cpu(
     blocks_per_chunk: int,
     layout_hints: Any | None = None,
     gpu_kv_format: Any | None = None,
+    out: list[torch.Tensor] | None = None,
 ) -> list[torch.Tensor]:
     """Gather paged KV blocks into CPU chunk tensors.
 
@@ -246,7 +251,7 @@ def gather_paged_kv_to_cpu(
     # tensors. Cast once so all downstream indexing is typed correctly.
     layer_tensors = cast(list[torch.Tensor], normalized)
 
-    chunks: list[torch.Tensor] = []
+    chunks: list[torch.Tensor] = [] if out is None else out
     for chunk_idx in range(num_chunks):
         chunk_block_ids = block_ids[
             chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk
@@ -261,7 +266,11 @@ def gather_paged_kv_to_cpu(
                         len(chunk_block_ids) * block_size, layer_blocks.shape[-1]
                     )
                 )
-            chunks.append(torch.stack(mla_layers, dim=0).cpu())
+            chunk_tensor = torch.stack(mla_layers, dim=0)
+            if out is not None:
+                out[chunk_idx].copy_(chunk_tensor, non_blocking=True)
+            else:
+                chunks.append(chunk_tensor.cpu())
         else:
             k_layers: list[torch.Tensor] = []
             v_layers: list[torch.Tensor] = []
@@ -310,7 +319,11 @@ def gather_paged_kv_to_cpu(
                     )
             k_stacked = torch.stack(k_layers, dim=0)
             v_stacked = torch.stack(v_layers, dim=0)
-            chunks.append(torch.stack([k_stacked, v_stacked], dim=0).cpu())
+            chunk_tensor = torch.stack([k_stacked, v_stacked], dim=0)
+            if out is not None:
+                out[chunk_idx].copy_(chunk_tensor, non_blocking=True)
+            else:
+                chunks.append(chunk_tensor.cpu())
     return chunks
 
 

--- a/lmcache/v1/multiprocess/non_gpu_context_pickle.py
+++ b/lmcache/v1/multiprocess/non_gpu_context_pickle.py
@@ -36,14 +36,8 @@ class NonGpuContextPickle(NonGpuContext):
     ) -> None:
         super().__init__(metadata, mq_client, mq_timeout)
 
-    def prepare_store(
-        self, key: Any, instance_id: int, block_ids: list[int], blocks_per_chunk: int
-    ) -> tuple[Any, list[torch.Tensor] | None]:
-        """Send PREPARE_STORE RPC. For pickle, returns no pre-allocated buffers.
-
-        Returns:
-            ``((key, instance_id), None)`` — gather will allocate its own tensors.
-        """
+    def prepare_store(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
+        """Send PREPARE_STORE RPC. For pickle, returns no pre-allocated buffers."""
         future = self.mq_client.submit_request(
             RequestType.PREPARE_STORE,
             [key, instance_id],
@@ -53,15 +47,16 @@ class NonGpuContextPickle(NonGpuContext):
             future.result(timeout=self.mq_timeout)
         except TimeoutError:
             pass
-        return ((key, instance_id), None)
+        return None
 
-    def commit_store(self, handle: Any, chunks: list[torch.Tensor]) -> bool:
+    def commit_store(
+        self, key: Any, instance_id: int, chunks: list[torch.Tensor]
+    ) -> bool:
         """Serialize chunks and send via COMMIT_STORE.
 
         Returns:
             ``True`` on success, ``False`` on failure or timeout.
         """
-        key, instance_id = handle
         serialised = pickle.dumps(chunks)
         future = self.mq_client.submit_request(
             RequestType.COMMIT_STORE,
@@ -73,14 +68,11 @@ class NonGpuContextPickle(NonGpuContext):
         except TimeoutError:
             return False
 
-    def prepare_retrieve(
-        self, key: Any, instance_id: int
-    ) -> tuple[Any, list[torch.Tensor] | None]:
+    def prepare_retrieve(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
         """Send PREPARE_RETRIEVE and deserialize the response data.
 
         Returns:
-            ``((key, instance_id), chunks)`` on hit, or
-            ``((key, instance_id), None)`` on miss/timeout.
+            Chunks on hit, or None on miss/timeout.
         """
         future = self.mq_client.submit_request(
             RequestType.PREPARE_RETRIEVE,
@@ -90,15 +82,14 @@ class NonGpuContextPickle(NonGpuContext):
         try:
             response = future.result(timeout=self.mq_timeout)
         except TimeoutError:
-            return ((key, instance_id), None)
+            return None
         if not response.success or not response.data:
-            return ((key, instance_id), None)
+            return None
         chunks: list[torch.Tensor] = pickle.loads(response.data)
-        return ((key, instance_id), chunks)
+        return chunks
 
-    def commit_retrieve(self, handle: Any) -> None:
+    def commit_retrieve(self, key: Any, instance_id: int) -> bool:
         """Send COMMIT_RETRIEVE (no-op for pickle path)."""
-        key, instance_id = handle
         future = self.mq_client.submit_request(
             RequestType.COMMIT_RETRIEVE,
             [key, instance_id],
@@ -108,6 +99,7 @@ class NonGpuContextPickle(NonGpuContext):
             future.result(timeout=self.mq_timeout)
         except TimeoutError:
             pass
+        return True
 
     def close(self) -> None:
         """No-op: the pickle path holds no persistent resources."""

--- a/lmcache/v1/multiprocess/non_gpu_context_pickle.py
+++ b/lmcache/v1/multiprocess/non_gpu_context_pickle.py
@@ -20,17 +20,12 @@ class NonGpuContextPickle(NonGpuContext):
     """Pickle-based implementation of :class:`NonGpuContext`.
 
     Transport mechanism:
-    - **Store**: ``prepare_store`` serialises chunks with ``pickle.dumps``; \
-``commit_store`` sends a ``STORE_CPU_CHUNKS`` message and waits for the \
-server acknowledgment.
-    - **Retrieve**: ``prepare_retrieve`` sends a ``RETRIEVE_CPU_CHUNKS`` \
-message, waits for the response, and deserialises the returned bytes with \
-``pickle.loads``; ``commit_retrieve`` is a no-op (no locks to release).
-
-    Args:
-        metadata: Layout metadata for the non-GPU context.
-        mq_client: Message-queue client for server communication.
-        mq_timeout: Timeout in seconds for blocking MQ requests.
+    - **Store**: ``prepare_store`` sends ``PREPARE_STORE`` (returns empty slots
+      for pickle mode); ``commit_store`` serialises chunks and sends
+      ``COMMIT_STORE``.
+    - **Retrieve**: ``prepare_retrieve`` sends ``PREPARE_RETRIEVE`` and
+      deserialises the returned bytes; ``commit_retrieve`` sends
+      ``COMMIT_RETRIEVE`` (no-op for pickle).
     """
 
     def __init__(
@@ -42,39 +37,36 @@ message, waits for the response, and deserialises the returned bytes with \
         super().__init__(metadata, mq_client, mq_timeout)
 
     def prepare_store(
-        self, key: Any, instance_id: int, chunks: list[torch.Tensor]
-    ) -> Any:
-        """Serialise *chunks* with ``pickle.dumps``.
-
-        Args:
-            key: Cache key for the token range to store.
-            instance_id: Worker instance identifier.
-            chunks: CPU chunk tensors to serialise.
+        self, key: Any, instance_id: int, block_ids: list[int], blocks_per_chunk: int
+    ) -> tuple[Any, list[torch.Tensor] | None]:
+        """Send PREPARE_STORE RPC. For pickle, returns no pre-allocated buffers.
 
         Returns:
-            Opaque handle ``(key, instance_id, serialised_bytes)`` to be
-            passed to :meth:`commit_store`.
+            ``((key, instance_id), None)`` — gather will allocate its own tensors.
         """
-        serialised = pickle.dumps(chunks)
-        return (key, instance_id, serialised)
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_STORE,
+            [key, instance_id],
+            get_response_class(RequestType.PREPARE_STORE),
+        )
+        try:
+            future.result(timeout=self.mq_timeout)
+        except TimeoutError:
+            pass
+        return ((key, instance_id), None)
 
-    def commit_store(self, handle: Any) -> bool:
-        """Send pickled chunks to the server via ``STORE_CPU_CHUNKS``.
-
-        Blocks until the server acknowledges the write.
-
-        Args:
-            handle: The ``(key, instance_id, bytes)`` tuple returned by
-                :meth:`prepare_store`.
+    def commit_store(self, handle: Any, chunks: list[torch.Tensor]) -> bool:
+        """Serialize chunks and send via COMMIT_STORE.
 
         Returns:
             ``True`` on success, ``False`` on failure or timeout.
         """
-        key, instance_id, serialised = handle
+        key, instance_id = handle
+        serialised = pickle.dumps(chunks)
         future = self.mq_client.submit_request(
-            RequestType.STORE_CPU_CHUNKS,
+            RequestType.COMMIT_STORE,
             [key, instance_id, serialised],
-            get_response_class(RequestType.STORE_CPU_CHUNKS),
+            get_response_class(RequestType.COMMIT_STORE),
         )
         try:
             return bool(future.result(timeout=self.mq_timeout))
@@ -84,41 +76,38 @@ message, waits for the response, and deserialises the returned bytes with \
     def prepare_retrieve(
         self, key: Any, instance_id: int
     ) -> tuple[Any, list[torch.Tensor] | None]:
-        """Fetch serialised chunks from the server via ``RETRIEVE_CPU_CHUNKS``.
-
-        Blocks until the server responds with the cached data (or reports a
-        miss).
-
-        Args:
-            key: Cache key for the token range to retrieve.
-            instance_id: Worker instance identifier.
+        """Send PREPARE_RETRIEVE and deserialize the response data.
 
         Returns:
-            ``(None, chunks)`` on cache hit where *chunks* is the
-            deserialised list of CPU tensors, or ``(None, None)`` on cache
-            miss or timeout.  The handle is ``None`` because the pickle path
-            has no resources to release in :meth:`commit_retrieve`.
+            ``((key, instance_id), chunks)`` on hit, or
+            ``((key, instance_id), None)`` on miss/timeout.
         """
         future = self.mq_client.submit_request(
-            RequestType.RETRIEVE_CPU_CHUNKS,
+            RequestType.PREPARE_RETRIEVE,
             [key, instance_id],
-            get_response_class(RequestType.RETRIEVE_CPU_CHUNKS),
+            get_response_class(RequestType.PREPARE_RETRIEVE),
         )
         try:
-            success, cpu_data_bytes = future.result(timeout=self.mq_timeout)
+            response = future.result(timeout=self.mq_timeout)
         except TimeoutError:
-            return (None, None)
-        if not success or not cpu_data_bytes:
-            return (None, None)
-        chunks: list[torch.Tensor] = pickle.loads(cpu_data_bytes)
-        return (None, chunks)
+            return ((key, instance_id), None)
+        if not response.success or not response.data:
+            return ((key, instance_id), None)
+        chunks: list[torch.Tensor] = pickle.loads(response.data)
+        return ((key, instance_id), chunks)
 
     def commit_retrieve(self, handle: Any) -> None:
-        """No-op: the pickle path holds no server-side locks.
-
-        Args:
-            handle: Ignored.
-        """
+        """Send COMMIT_RETRIEVE (no-op for pickle path)."""
+        key, instance_id = handle
+        future = self.mq_client.submit_request(
+            RequestType.COMMIT_RETRIEVE,
+            [key, instance_id],
+            get_response_class(RequestType.COMMIT_RETRIEVE),
+        )
+        try:
+            future.result(timeout=self.mq_timeout)
+        except TimeoutError:
+            pass
 
     def close(self) -> None:
         """No-op: the pickle path holds no persistent resources."""

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -49,8 +49,10 @@ class RequestType(enum.Enum):
     FREE_LOOKUP_LOCKS = enum.auto()
     END_SESSION = enum.auto()
     REGISTER_KV_CACHE_NON_GPU_CONTEXT = enum.auto()
-    STORE_CPU_CHUNKS = enum.auto()
-    RETRIEVE_CPU_CHUNKS = enum.auto()
+    PREPARE_STORE = enum.auto()
+    COMMIT_STORE = enum.auto()
+    PREPARE_RETRIEVE = enum.auto()
+    COMMIT_RETRIEVE = enum.auto()
 
     # Controller operations
     CLEAR = enum.auto()

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -26,23 +26,12 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
 
 
-@dataclass
-class ShmSlotMetadata:
-    """Metadata for one SHM slot."""
-
-    key: str
-    shm_name: str
-    offset: int
-    length: int
-    shape: list[int]
-    dtype: str
-
 
 @dataclass
 class PrepareStoreResponse:
     """Response for PREPARE_STORE."""
 
-    slots: list[ShmSlotMetadata] = field(default_factory=list)
+    context: dict = field(default_factory=dict)  # pickle: {}, shm will put slot info here
 
 
 @dataclass
@@ -51,7 +40,7 @@ class PrepareRetrieveResponse:
 
     success: bool
     data: bytes = b""
-    slots: list[ShmSlotMetadata] = field(default_factory=list)
+    context: dict = field(default_factory=dict)  # pickle: {}, shm will put slot info here
 
 
 # Define request names for this protocol group

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -12,6 +12,9 @@ This module defines the protocol for:
 - END_SESSION: End a session and clean up associated resources
 """
 
+# Standard
+from dataclasses import dataclass, field
+
 # First Party
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
@@ -21,6 +24,35 @@ from lmcache.v1.multiprocess.custom_types import (
     RegisterNonGpuContextPayload,
 )
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
+
+
+@dataclass
+class ShmSlotMetadata:
+    """Metadata for one SHM slot."""
+
+    key: str
+    shm_name: str
+    offset: int
+    length: int
+    shape: list[int]
+    dtype: str
+
+
+@dataclass
+class PrepareStoreResponse:
+    """Response for PREPARE_STORE."""
+
+    slots: list[ShmSlotMetadata] = field(default_factory=list)
+
+
+@dataclass
+class PrepareRetrieveResponse:
+    """Response for PREPARE_RETRIEVE."""
+
+    success: bool
+    data: bytes = b""
+    slots: list[ShmSlotMetadata] = field(default_factory=list)
+
 
 # Define request names for this protocol group
 REQUEST_NAMES = [
@@ -34,8 +66,10 @@ REQUEST_NAMES = [
     "FREE_LOOKUP_LOCKS",
     "END_SESSION",
     "REGISTER_KV_CACHE_NON_GPU_CONTEXT",
-    "STORE_CPU_CHUNKS",
-    "RETRIEVE_CPU_CHUNKS",
+    "PREPARE_STORE",
+    "COMMIT_STORE",
+    "PREPARE_RETRIEVE",
+    "COMMIT_RETRIEVE",
 ]
 
 # Type alias for cache keys
@@ -159,14 +193,24 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),
-        "STORE_CPU_CHUNKS": ProtocolDefinition(
+        "PREPARE_STORE": ProtocolDefinition(
+            payload_classes=[KeyType, int],
+            response_class=PrepareStoreResponse,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        "COMMIT_STORE": ProtocolDefinition(
             payload_classes=[KeyType, int, bytes],
             response_class=bool,
             handler_type=HandlerType.BLOCKING,
         ),
-        "RETRIEVE_CPU_CHUNKS": ProtocolDefinition(
+        "PREPARE_RETRIEVE": ProtocolDefinition(
             payload_classes=[KeyType, int],
-            response_class=tuple[bool, bytes],
+            response_class=PrepareRetrieveResponse,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        "COMMIT_RETRIEVE": ProtocolDefinition(
+            payload_classes=[KeyType, int],
+            response_class=bool,
             handler_type=HandlerType.BLOCKING,
         ),
     }

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -419,7 +419,7 @@ class MPCacheEngine:
             PrepareStoreResponse with empty slots for pickle mode.
         """
 
-        return PrepareStoreResponse(slots=[])
+        return PrepareStoreResponse(context={})
 
     @_lmcache_nvtx_annotate
     def commit_store(
@@ -499,14 +499,14 @@ class MPCacheEngine:
         try:
             with self.storage_manager.read_prefetched_results(obj_keys) as memory_objs:
                 if not memory_objs or len(memory_objs) != len(obj_keys):
-                    return PrepareRetrieveResponse(success=False)
+                    return PrepareRetrieveResponse(success=False, data=b"", context={})
                 prefetched_keys = obj_keys[: len(memory_objs)]
                 chunks = []
                 for memory_obj in memory_objs:
                     if memory_obj.tensor is None:
-                        return PrepareRetrieveResponse(success=False)
+                        return PrepareRetrieveResponse(success=False, data=b"", context={})
                     chunks.append(memory_obj.tensor.cpu().clone())
-                return PrepareRetrieveResponse(success=True, data=pickle.dumps(chunks))
+                return PrepareRetrieveResponse(success=True, data=pickle.dumps(chunks), context={})
         finally:
             if prefetched_keys:
                 self.storage_manager.finish_read_prefetched(prefetched_keys)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -69,6 +69,10 @@ from lmcache.v1.multiprocess.protocol import (
     get_handler_type,
     get_payload_classes,
 )
+from lmcache.v1.multiprocess.protocols.engine import (
+    PrepareRetrieveResponse,
+    PrepareStoreResponse,
+)
 from lmcache.v1.multiprocess.session import SessionManager
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 import lmcache.c_ops as lmc_ops
@@ -400,13 +404,31 @@ class MPCacheEngine:
         return ipc_key_to_object_keys(key, chunk_hashes)
 
     @_lmcache_nvtx_annotate
-    def store_cpu_chunks(
+    def prepare_store(
+        self,
+        key: IPCCacheEngineKey,
+        instance_id: int,
+    ) -> PrepareStoreResponse:
+        """Prepare a store operation. For pickle mode, returns empty slots.
+
+        Args:
+            key: Cache key for the token range to store.
+            instance_id: Worker instance identifier.
+
+        Returns:
+            PrepareStoreResponse with empty slots for pickle mode.
+        """
+
+        return PrepareStoreResponse(slots=[])
+
+    @_lmcache_nvtx_annotate
+    def commit_store(
         self,
         key: IPCCacheEngineKey,
         instance_id: int,
         cpu_data: bytes,
     ) -> bool:
-        """Store worker-provided CPU chunks for non-CUDA cpu context mode.
+        """Commit serialized CPU chunks to storage.
 
         Args:
             key: Cache key for the token range to store.
@@ -415,9 +437,6 @@ class MPCacheEngine:
 
         Returns:
             ``True`` when all reserved objects are written, otherwise ``False``.
-
-        Raises:
-            ValueError: If the instance has no registered cpu context.
         """
         obj_keys = self._resolve_obj_keys(key)
 
@@ -453,11 +472,11 @@ class MPCacheEngine:
         return len(written_keys) == len(reserved_dict)
 
     @_lmcache_nvtx_annotate
-    def retrieve_cpu_chunks(
+    def prepare_retrieve(
         self,
         key: IPCCacheEngineKey,
         instance_id: int,
-    ) -> tuple[bool, bytes]:
+    ) -> PrepareRetrieveResponse:
         """Retrieve prefetched chunks and return serialized CPU tensors.
 
         Args:
@@ -465,12 +484,9 @@ class MPCacheEngine:
             instance_id: Worker instance identifier.
 
         Returns:
-            Tuple ``(success, payload)`` where ``payload`` is a pickled
-            list of CPU chunk tensors.
-
-        Raises:
-            ValueError: If the instance has no registered cpu context.
+            PrepareRetrieveResponse with serialized data on hit.
         """
+
         obj_keys = self._resolve_obj_keys(key)
 
         context = self.contexts.get(instance_id)
@@ -483,17 +499,34 @@ class MPCacheEngine:
         try:
             with self.storage_manager.read_prefetched_results(obj_keys) as memory_objs:
                 if not memory_objs or len(memory_objs) != len(obj_keys):
-                    return False, b""
+                    return PrepareRetrieveResponse(success=False)
                 prefetched_keys = obj_keys[: len(memory_objs)]
                 chunks = []
                 for memory_obj in memory_objs:
                     if memory_obj.tensor is None:
-                        return False, b""
+                        return PrepareRetrieveResponse(success=False)
                     chunks.append(memory_obj.tensor.cpu().clone())
-                return True, pickle.dumps(chunks)
+                return PrepareRetrieveResponse(success=True, data=pickle.dumps(chunks))
         finally:
             if prefetched_keys:
                 self.storage_manager.finish_read_prefetched(prefetched_keys)
+
+    @_lmcache_nvtx_annotate
+    def commit_retrieve(
+        self,
+        key: IPCCacheEngineKey,
+        instance_id: int,
+    ) -> bool:
+        """Finalize a retrieve operation. No-op for pickle mode.
+
+        Args:
+            key: Cache key (unused for pickle).
+            instance_id: Worker instance identifier (unused for pickle).
+
+        Returns:
+            Always ``True``.
+        """
+        return True
 
     @_lmcache_nvtx_annotate
     def store(
@@ -1400,7 +1433,7 @@ def run_cache_server(
         RequestType.REGISTER_KV_CACHE_NON_GPU_CONTEXT,
         engine.register_kv_cache_non_gpu_context,
     )
-    add_handler_helper(server, RequestType.STORE_CPU_CHUNKS, engine.store_cpu_chunks)
+    add_handler_helper(server, RequestType.PREPARE_STORE, engine.prepare_store)
     add_handler_helper(server, RequestType.LOOKUP, engine.lookup)
     add_handler_helper(
         server, RequestType.QUERY_PREFETCH_STATUS, engine.query_prefetch_status
@@ -1412,9 +1445,9 @@ def run_cache_server(
     )
     add_handler_helper(server, RequestType.FREE_LOOKUP_LOCKS, engine.free_lookup_locks)
     add_handler_helper(server, RequestType.RETRIEVE, engine.retrieve)
-    add_handler_helper(
-        server, RequestType.RETRIEVE_CPU_CHUNKS, engine.retrieve_cpu_chunks
-    )
+    add_handler_helper(server, RequestType.COMMIT_STORE, engine.commit_store)
+    add_handler_helper(server, RequestType.PREPARE_RETRIEVE, engine.prepare_retrieve)
+    add_handler_helper(server, RequestType.COMMIT_RETRIEVE, engine.commit_retrieve)
     add_handler_helper(server, RequestType.CLEAR, engine.clear)
     add_handler_helper(server, RequestType.GET_CHUNK_SIZE, engine.get_chunk_size)
     add_handler_helper(server, RequestType.PING, engine.ping)
@@ -1431,8 +1464,10 @@ def run_cache_server(
         [
             RequestType.STORE,
             RequestType.RETRIEVE,
-            RequestType.STORE_CPU_CHUNKS,
-            RequestType.RETRIEVE_CPU_CHUNKS,
+            RequestType.PREPARE_STORE,
+            RequestType.COMMIT_STORE,
+            RequestType.PREPARE_RETRIEVE,
+            RequestType.COMMIT_RETRIEVE,
         ],
         max_workers=mp_config.max_gpu_workers,
     )

--- a/lmcache/v1/multiprocess/transfer_context.py
+++ b/lmcache/v1/multiprocess/transfer_context.py
@@ -317,15 +317,18 @@ class NonCudaTransferContext(TransferContext):
             )
 
         torch_dev.synchronize()
+        handle, out_buffers = self._non_gpu_context.prepare_store(
+            key, instance_id, block_ids, blocks_in_chunk
+        )
         cpu_chunks = gather_paged_kv_to_cpu(
             kv_caches,
             block_ids,
             blocks_in_chunk,
             layout_hints=self._layout_hints,
             gpu_kv_format=self._gpu_kv_format,
+            out=out_buffers,
         )
-        handle = self._non_gpu_context.prepare_store(key, instance_id, cpu_chunks)
-        ok = self._non_gpu_context.commit_store(handle)
+        ok = self._non_gpu_context.commit_store(handle, cpu_chunks)
 
         future: MessagingFuture[bool] = MessagingFuture()
         future.set_result(ok)

--- a/lmcache/v1/multiprocess/transfer_context.py
+++ b/lmcache/v1/multiprocess/transfer_context.py
@@ -317,9 +317,7 @@ class NonCudaTransferContext(TransferContext):
             )
 
         torch_dev.synchronize()
-        handle, out_buffers = self._non_gpu_context.prepare_store(
-            key, instance_id, block_ids, blocks_in_chunk
-        )
+        out_buffers = self._non_gpu_context.prepare_store(key, instance_id)
         cpu_chunks = gather_paged_kv_to_cpu(
             kv_caches,
             block_ids,
@@ -328,7 +326,7 @@ class NonCudaTransferContext(TransferContext):
             gpu_kv_format=self._gpu_kv_format,
             out=out_buffers,
         )
-        ok = self._non_gpu_context.commit_store(handle, cpu_chunks)
+        ok = self._non_gpu_context.commit_store(key, instance_id, cpu_chunks)
 
         future: MessagingFuture[bool] = MessagingFuture()
         future.set_result(ok)
@@ -351,14 +349,14 @@ class NonCudaTransferContext(TransferContext):
                 "Call register() before submit_retrieve()."
             )
 
-        handle, chunks = self._non_gpu_context.prepare_retrieve(key, instance_id)
-        ok = chunks is not None
-        if chunks is not None:
+        src_buffers = self._non_gpu_context.prepare_retrieve(key, instance_id)
+        ok = src_buffers is not None
+        if src_buffers is not None:
             try:
                 scatter_cpu_to_paged_kv(
                     kv_caches,
                     block_ids,
-                    chunks,
+                    src_buffers,
                     blocks_in_chunk,
                     skip_first_n_tokens=skip_first_n_tokens,
                     layout_hints=self._layout_hints,
@@ -367,7 +365,7 @@ class NonCudaTransferContext(TransferContext):
             except (RuntimeError, ValueError, TypeError, IndexError):
                 logger.exception("Failed to scatter retrieved CPU context chunks")
                 ok = False
-        self._non_gpu_context.commit_retrieve(handle)
+        self._non_gpu_context.commit_retrieve(key, instance_id)
 
         future: MessagingFuture[bool] = MessagingFuture()
         future.set_result(ok)

--- a/tests/v1/multiprocess/test_non_cuda_context.py
+++ b/tests/v1/multiprocess/test_non_cuda_context.py
@@ -448,8 +448,10 @@ def test_server_store_and_retrieve_cpu_chunks(stub_native_storage_ops: Any) -> N
         "lmcache.v1.multiprocess.server.ipc_key_to_object_keys",
         return_value=["obj"],
     ):
-        store_ok = engine.store_cpu_chunks(key, 2, pickle.dumps([payload]))
-        success, cpu_data = engine.retrieve_cpu_chunks(key, 2)
+        store_ok = engine.commit_store(key, 2, pickle.dumps([payload]))
+        response = engine.prepare_retrieve(key, 2)
+        success = response.success
+        cpu_data = response.data
     assert isinstance(store_ok, bool)
     assert torch.allclose(mock_memory_obj.tensor, payload)
 


### PR DESCRIPTION
## Summary

Adds zero-copy buffer pre-allocation support to the non-GPU context interface, enabling subsequent SHM implementations to do direct GPU→shm transfers without intermediate CPU tensor allocation.

### Changes

1. **`non_gpu_context.py`**:
   - Added `out: list[torch.Tensor] | None = None` parameter to `gather_paged_kv_to_cpu` — when provided, copies directly into the given buffers via `.copy_(src, non_blocking=True)` instead of allocating new CPU tensors
   - Added `allocate_store_buffers()` and `allocate_retrieve_buffers()` methods to `NonGpuContext` ABC (default returns `None`)
   - Added `src: list[torch.Tensor] | None = None` parameter to `scatter_cpu_to_paged_kv` for the retrieve path

2. **`transfer_context.py`**:
   - `NonCudaTransferContext.submit_store` now calls `allocate_store_buffers()` and passes the result as `out=` to `gather_paged_kv_to_cpu`

### Motivation

This enables the SHM-backed `NonGpuContext` implementation to pre-allocate shared memory buffers, so that `gather_paged_kv_to_cpu` writes directly into shm without an extra copy step.