### PR TITLE
feat: shm-backed zero-copy buffer allocation for NonGpuContextShm

### DIFF
--- a/lmcache/v1/multiprocess/non_gpu_context.py
+++ b/lmcache/v1/multiprocess/non_gpu_context.py
@@ -121,6 +121,36 @@ class NonGpuContext(ABC):
         """
         ...
 
+    def allocate_store_buffers(
+        self, num_chunks: int, chunk_shape: list[int], dtype: torch.dtype
+    ) -> list[torch.Tensor] | None:
+        """Pre-allocate target buffers for store.
+
+        Args:
+            num_chunks: Number of chunks to allocate.
+            chunk_shape: Shape of each chunk tensor.
+            dtype: Data type of the chunk tensors.
+
+        Returns:
+            A list of pre-allocated tensors, or ``None`` to use default.
+        """
+        return None
+
+    def allocate_retrieve_buffers(
+        self, num_chunks: int, chunk_shape: list[int], dtype: torch.dtype
+    ) -> list[torch.Tensor] | None:
+        """Pre-allocate source buffers for retrieve.
+
+        Args:
+            num_chunks: Number of chunks to allocate.
+            chunk_shape: Shape of each chunk tensor.
+            dtype: Data type of the chunk tensors.
+
+        Returns:
+            A list of pre-allocated tensors, or ``None`` to use default.
+        """
+        return None
+
     @abstractmethod
     def close(self) -> None:
         """Release any resources held by this context."""
@@ -208,6 +238,7 @@ def gather_paged_kv_to_cpu(
     blocks_per_chunk: int,
     layout_hints: Any | None = None,
     gpu_kv_format: Any | None = None,
+    out: list[torch.Tensor] | None = None,
 ) -> list[torch.Tensor]:
     """Gather paged KV blocks into CPU chunk tensors.
 
@@ -266,7 +297,11 @@ def gather_paged_kv_to_cpu(
                         len(chunk_block_ids) * block_size, layer_blocks.shape[-1]
                     )
                 )
-            chunks.append(torch.stack(mla_layers, dim=0).cpu())
+            gpu_chunk = torch.stack(mla_layers, dim=0)
+            if out is not None:
+                out[chunk_idx].copy_(gpu_chunk, non_blocking=True)
+            else:
+                chunks.append(gpu_chunk.cpu())
         else:
             k_layers: list[torch.Tensor] = []
             v_layers: list[torch.Tensor] = []
@@ -315,8 +350,12 @@ def gather_paged_kv_to_cpu(
                     )
             k_stacked = torch.stack(k_layers, dim=0)
             v_stacked = torch.stack(v_layers, dim=0)
-            chunks.append(torch.stack([k_stacked, v_stacked], dim=0).cpu())
-    return chunks
+            gpu_chunk = torch.stack([k_stacked, v_stacked], dim=0)
+            if out is not None:
+                out[chunk_idx].copy_(gpu_chunk, non_blocking=True)
+            else:
+                chunks.append(gpu_chunk.cpu())
+    return out if out is not None else chunks
 
 
 def scatter_cpu_to_paged_kv(

--- a/lmcache/v1/multiprocess/non_gpu_context_shm.py
+++ b/lmcache/v1/multiprocess/non_gpu_context_shm.py
@@ -43,10 +43,63 @@ class NonGpuContextShm(NonGpuContext):
             )
         self._buffer = self._shm.buf
 
+    def allocate_store_buffers(
+        self, num_chunks: int, chunk_shape: list[int], dtype: torch.dtype
+    ) -> list[torch.Tensor] | None:
+        """Reserve SHM slots and return shm-backed tensor views for store."""
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_STORE,
+            [None, None, num_chunks],
+            get_response_class(RequestType.PREPARE_STORE),
+        )
+        response: PrepareStoreResponse = future.result(timeout=self.mq_timeout)
+        if not response.slots:
+            return None
+        buffers: list[torch.Tensor] = []
+        for slot in response.slots:
+            buffers.append(
+                self._make_tensor_view(slot.offset, slot.length, slot.shape, slot.dtype)
+            )
+        # Stash the response for prepare_store to use.
+        self._pending_store_response = response
+        return buffers
+
+    def allocate_retrieve_buffers(
+        self, num_chunks: int, chunk_shape: list[int], dtype: torch.dtype
+    ) -> list[torch.Tensor] | None:
+        """Reserve SHM slots and return shm-backed tensor views for retrieve."""
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_RETRIEVE,
+            [None, None, num_chunks],
+            get_response_class(RequestType.PREPARE_RETRIEVE),
+        )
+        response: PrepareRetrieveResponse = future.result(timeout=self.mq_timeout)
+        if not response.success or not response.slots:
+            return None
+        buffers: list[torch.Tensor] = []
+        for slot in response.slots:
+            buffers.append(
+                self._make_tensor_view(slot.offset, slot.length, slot.shape, slot.dtype)
+            )
+        self._pending_retrieve_response = response
+        return buffers
+
     def prepare_store(
         self, key: Any, instance_id: int, chunks: list[torch.Tensor]
     ) -> Any:
-        """Prepare a SHM store and copy chunks into reserved slots."""
+        """Prepare a SHM store.
+
+        If allocate_store_buffers was called, data is already in SHM slots
+        and we just need to finalize with key/instance_id. Otherwise fall back
+        to the original copy path.
+        """
+        pending = getattr(self, "_pending_store_response", None)
+        if pending is not None:
+            # Data already in SHM via allocate_store_buffers; just record key.
+            self._pending_store_response = None
+            return (key, instance_id, True)
+
+        # Fallback: RPC for slot reservation and copy chunks in.
         future = self.mq_client.submit_request(
             RequestType.PREPARE_STORE,
             [key, instance_id],

--- a/lmcache/v1/multiprocess/transfer_context.py
+++ b/lmcache/v1/multiprocess/transfer_context.py
@@ -330,12 +330,24 @@ class NonCudaTransferContext(TransferContext):
         ok = False
         try:
             torch_dev.synchronize()
+
+            # Compute chunk shape/dtype for buffer pre-allocation.
+            num_chunks = len(block_ids) // blocks_in_chunk
+            layout_desc = self._non_gpu_context.layout_desc
+            chunk_shape = list(layout_desc.shapes[0])
+            chunk_dtype = layout_desc.dtypes[0]
+
+            out_buffers = self._non_gpu_context.allocate_store_buffers(
+                num_chunks, chunk_shape, chunk_dtype
+            )
+
             cpu_chunks = gather_paged_kv_to_cpu(
                 kv_caches,
                 block_ids,
                 blocks_in_chunk,
                 layout_hints=self._layout_hints,
                 gpu_kv_format=self._gpu_kv_format,
+                out=out_buffers,
             )
             handle = self._non_gpu_context.prepare_store(key, instance_id, cpu_chunks)
             ok = self._non_gpu_context.commit_store(handle)


### PR DESCRIPTION
## Summary

Implements zero-copy GPU→shm transfers by overriding `allocate_store_buffers` and `allocate_retrieve_buffers` in the SHM context.

### Changes

1. **`non_gpu_context.py`** (interface layer):
   - Added `allocate_store_buffers()` / `allocate_retrieve_buffers()` to ABC (default `None`)
   - Added `out` parameter to `gather_paged_kv_to_cpu` for direct copy into pre-allocated buffers

2. **`non_gpu_context_shm.py`**:
   - `allocate_store_buffers`: RPCs to server for slot reservation, returns shm-backed tensor views
   - `allocate_retrieve_buffers`: Same pattern for the retrieve path
   - `prepare_store`: Simplified — when buffers were pre-allocated, data is already in SHM

3. **`transfer_context.py`**:
   - Calls `allocate_store_buffers()` and passes result as `out=` to `gather_paged_kv_to_cpu`

### How it works

The flow is now:
1. `allocate_store_buffers()` → RPC reserves SHM slots → returns tensor views over shm
2. `gather_paged_kv_to_cpu(out=views)` → GPU data copied directly into shm (zero-copy)
3. `prepare_store()` → detects pre-allocated path, skips redundant copy
4. `commit_store()` → finalizes with server

Depends on interface additions from PR #271.