### PR TITLE
Add shared-memory (SHM) transport for non-GPU context

### DIFF
--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -8,6 +8,7 @@ Configuration for distributed storage manager
 from dataclasses import dataclass, field
 from typing import Literal
 import argparse
+import os
 
 # First Party
 from lmcache import torch_dev
@@ -38,6 +39,9 @@ class L1MemoryManagerConfig:
 
     align_bytes: int = field(default=0x1000)
     """ The alignment size in bytes. Default is 4KB. """
+
+    shm_name: str = field(default_factory=lambda: f"lmcache_l1_pool_{os.getpid()}")
+    """ Name of the POSIX shared-memory segment for zero-copy worker access. """
 
     def __post_init__(self):
         self.init_size_in_bytes = min(self.init_size_in_bytes, self.size_in_bytes)

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -803,6 +803,10 @@ class L1Manager:
         """Return an L1MemoryDesc describing the underlying L1 memory buffer."""
         return self._memory_manager.get_l1_memory_desc()
 
+    def get_shm_pool_info(self) -> dict[str, object]:
+        """Return shared-memory pool metadata for worker attachment."""
+        return self._memory_manager.get_shm_pool_info()
+
     def close(self) -> None:
         """Close the L1Manager and free all resources."""
         with self._lock:

--- a/lmcache/v1/distributed/memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager.py
@@ -65,9 +65,19 @@ def create_memory_allocator(config: L1MemoryManagerConfig) -> MemoryAllocatorInt
         MemoryAllocatorInterface: An instance of a memory allocator.
     """
     shm_name = getattr(config, "shm_name", "") or ""
+    effective_shm_name: str | None = None
     if shm_name and not config.use_lazy:
-        _unlink_stale_shm(shm_name)
-        _check_shm_capacity(config.size_in_bytes)
+        try:
+            _unlink_stale_shm(shm_name)
+            _check_shm_capacity(config.size_in_bytes)
+            effective_shm_name = shm_name
+        except (RuntimeError, OSError) as exc:
+            logger.warning(
+                "Failed to initialize SHM pool (%s), falling back to pickle mode: %s",
+                shm_name,
+                exc,
+            )
+            effective_shm_name = None
 
     if config.use_lazy:
         logger.debug(
@@ -83,14 +93,15 @@ def create_memory_allocator(config: L1MemoryManagerConfig) -> MemoryAllocatorInt
     else:
         logger.debug(
             "use mixed memory allocator, total size is %d bytes, "
-            "align bytes is %d bytes",
+            "align bytes is %d bytes, shm_name=%s",
             config.size_in_bytes,
             config.align_bytes,
+            effective_shm_name or "(none, pickle mode)",
         )
         return MixedMemoryAllocator(
             config.size_in_bytes,
             align_bytes=config.align_bytes,
-            shm_name=getattr(config, "shm_name", None) or None,
+            shm_name=effective_shm_name,
         )
 
 
@@ -108,7 +119,11 @@ class L1MemoryManager:
         self._allocator = create_memory_allocator(config)
         self._size_in_bytes = config.size_in_bytes
         self._align_bytes = config.align_bytes
-        self._shm_name = getattr(config, "shm_name", "")
+        # Reflect actual shm state from allocator (may have fallen back to pickle)
+        if isinstance(self._allocator, MixedMemoryAllocator):
+            self._shm_name = getattr(self._allocator, "shm_name", "") or ""
+        else:
+            self._shm_name = ""
 
     def allocate(
         self, layout_desc: MemoryLayoutDesc, count: int

--- a/lmcache/v1/distributed/memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+import os
+import shutil
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
@@ -16,6 +20,39 @@ from lmcache.v1.memory_management import (
 logger = init_logger(__name__)
 
 
+def _check_shm_capacity(required_bytes: int) -> None:
+    """Verify that /dev/shm has sufficient free space."""
+    shm_stat = shutil.disk_usage("/dev/shm")
+    if shm_stat.free < required_bytes:
+        size_gib = (required_bytes / 2**30) + 1
+        raise RuntimeError(
+            f"Insufficient /dev/shm space: need {required_bytes / 2**30:.1f} GiB, "
+            f"available {shm_stat.free / 2**30:.1f} GiB. "
+            f"Increase /dev/shm capacity (e.g. 'docker run --shm-size={size_gib:.0f}g')."
+        )
+
+
+def _unlink_stale_shm(shm_name: str) -> None:
+    """Remove stale lmcache shm segments not held by any live process."""
+    shm_dir = "/dev/shm"
+    prefix = "lmcache_l1_pool_"
+    try:
+        entries = os.listdir(shm_dir)
+    except OSError:
+        return
+    for entry in entries:
+        if entry != shm_name and not entry.startswith(prefix):
+            continue
+        if entry == shm_name:
+            # Remove our own stale segment from a previous run
+            shm_path = os.path.join(shm_dir, entry)
+            try:
+                os.unlink(shm_path)
+                logger.info("Removed stale shared-memory segment: %s", shm_path)
+            except OSError:
+                pass
+
+
 # HELPER FUNCTIONS
 def create_memory_allocator(config: L1MemoryManagerConfig) -> MemoryAllocatorInterface:
     """
@@ -27,6 +64,11 @@ def create_memory_allocator(config: L1MemoryManagerConfig) -> MemoryAllocatorInt
     Returns:
         MemoryAllocatorInterface: An instance of a memory allocator.
     """
+    shm_name = getattr(config, "shm_name", "") or ""
+    if shm_name and not config.use_lazy:
+        _unlink_stale_shm(shm_name)
+        _check_shm_capacity(config.size_in_bytes)
+
     if config.use_lazy:
         logger.debug(
             "use lazy memory allocator, init size is %d bytes, "
@@ -48,6 +90,7 @@ def create_memory_allocator(config: L1MemoryManagerConfig) -> MemoryAllocatorInt
         return MixedMemoryAllocator(
             config.size_in_bytes,
             align_bytes=config.align_bytes,
+            shm_name=getattr(config, "shm_name", None) or None,
         )
 
 

--- a/lmcache/v1/distributed/memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager.py
@@ -65,6 +65,7 @@ class L1MemoryManager:
         self._allocator = create_memory_allocator(config)
         self._size_in_bytes = config.size_in_bytes
         self._align_bytes = config.align_bytes
+        self._shm_name = getattr(config, "shm_name", "")
 
     def allocate(
         self, layout_desc: MemoryLayoutDesc, count: int
@@ -167,6 +168,13 @@ class L1MemoryManager:
             size=self._size_in_bytes,
             align_bytes=self._align_bytes,
         )
+
+    def get_shm_pool_info(self) -> dict[str, object]:
+        """Return shared-memory pool metadata for worker attachment."""
+        return {
+            "shm_name": self._shm_name,
+            "pool_size": self._size_in_bytes,
+        }
 
     def close(self) -> None:
         """

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -631,6 +631,23 @@ class StorageManager:
         }
 
     # Functions for debugging and testing
+    def get_shm_pool_info(self) -> dict[str, object]:
+        """Return shared-memory pool metadata for worker attachment."""
+        return self._l1_manager.get_shm_pool_info()
+
+    def unsafe_read(
+        self, keys: list[ObjectKey]
+    ) -> tuple[list[ObjectKey], list[MemoryObj]]:
+        """Read already-read-locked objects without acquiring new locks."""
+        read_results = self._l1_manager.unsafe_read(keys)
+        good_keys: list[ObjectKey] = []
+        good_objs: list[MemoryObj] = []
+        for key, (_err, obj) in read_results.items():
+            if obj is not None:
+                good_keys.append(key)
+                good_objs.append(obj)
+        return good_keys, good_objs
+
     def memcheck(self) -> bool:
         """
         Perform memory check for all storage tiers.

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -350,6 +350,16 @@ class MemoryObj(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @property
+    def shm_offset(self) -> int:
+        """Offset of this object relative to the shared-memory pool base."""
+        return self.meta.address
+
+    @property
+    def shm_byte_length(self) -> int:
+        """Logical byte length of this object in the shared-memory pool."""
+        return self.get_size()
+
+    @property
     @abc.abstractmethod
     def raw_tensor(self) -> Optional[torch.Tensor]:
         """

--- a/lmcache/v1/multiprocess/non_gpu_context.py
+++ b/lmcache/v1/multiprocess/non_gpu_context.py
@@ -100,24 +100,45 @@ def create_non_gpu_context(
     metadata: NonGpuContextMetadata,
     mq_client: Any,
     mq_timeout: float,
+    shm_name: str = "",
+    pool_size: int = 0,
 ) -> NonGpuContext:
     """Factory that returns the appropriate :class:`NonGpuContext` implementation.
 
-    Currently always returns a pickle-based implementation
-    (``NonGpuContextPickle``). A future SHM-capable PR
-    may probe for shared-memory availability and fall back to pickle.
+    If ``shm_name`` is non-empty and ``pool_size > 0``, returns a shared-memory
+    implementation that uses zero-copy tensor views. Otherwise falls back to
+    the pickle-based implementation.
 
     Args:
         metadata: Layout metadata for the non-GPU context.
         mq_client: Message-queue client for server communication.
         mq_timeout: Timeout in seconds for blocking MQ requests.
+        shm_name: Name of the shared-memory segment (empty → pickle mode).
+        pool_size: Size in bytes of the shared-memory pool (0 → pickle mode).
 
     Returns:
         A concrete :class:`NonGpuContext` instance.
     """
+    # Standard
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    if shm_name and pool_size > 0:
+        # Local
+        from .non_gpu_context_shm import NonGpuContextShm
+
+        logger.info(
+            "Using SHM non-GPU context (shm_name=%s, pool_size=%d)",
+            shm_name,
+            pool_size,
+        )
+        return NonGpuContextShm(metadata, mq_client, mq_timeout, shm_name, pool_size)
+
     # Local
     from .non_gpu_context_pickle import NonGpuContextPickle
 
+    logger.info("Using pickle non-GPU context")
     return NonGpuContextPickle(metadata, mq_client, mq_timeout)
 
 

--- a/lmcache/v1/multiprocess/non_gpu_context_shm.py
+++ b/lmcache/v1/multiprocess/non_gpu_context_shm.py
@@ -35,6 +35,9 @@ class NonGpuContextShm(NonGpuContext):
     ) -> None:
         super().__init__(metadata, mq_client, mq_timeout)
         self._shm = SharedMemory(name=shm_name, create=False)
+        # Prevent worker from unlinking the segment on GC/exit —
+        # the segment lifecycle is owned by the server process.
+        self._shm.unlink = lambda: None  # type: ignore[method-assign]
         self._pool_size = pool_size
         self._buffer = self._shm.buf
 

--- a/lmcache/v1/multiprocess/non_gpu_context_shm.py
+++ b/lmcache/v1/multiprocess/non_gpu_context_shm.py
@@ -2,7 +2,8 @@
 """Shared-memory NonGpuContext implementation for multiprocess mode."""
 
 # Standard
-from multiprocessing.shared_memory import SharedMemory
+import mmap
+import os
 from typing import Any
 
 # Third Party
@@ -34,12 +35,16 @@ class NonGpuContextShm(NonGpuContext):
         pool_size: int,
     ) -> None:
         super().__init__(metadata, mq_client, mq_timeout)
-        self._shm = SharedMemory(name=shm_name, create=False)
-        # Prevent worker from unlinking the segment on GC/exit —
-        # the segment lifecycle is owned by the server process.
-        self._shm.unlink = lambda: None  # type: ignore[method-assign]
+        # Attach to the server's shm segment via mmap (not SharedMemory)
+        # to avoid Python's resource_tracker unlinking on worker exit.
+        shm_path = f"/dev/shm/{shm_name}"
+        fd = os.open(shm_path, os.O_RDWR)
+        try:
+            self._mmap = mmap.mmap(fd, pool_size)
+        finally:
+            os.close(fd)
         self._pool_size = pool_size
-        self._buffer = self._shm.buf
+        self._buffer = self._mmap
 
     def _make_tensor_view(
         self, offset: int, length: int, shape: list[int], dtype_str: str
@@ -131,6 +136,6 @@ class NonGpuContextShm(NonGpuContext):
         """Release buffer and close shared memory attachment."""
         self._buffer = None
         try:
-            self._shm.close()
+            self._mmap.close()
         except Exception:
             pass

--- a/lmcache/v1/multiprocess/non_gpu_context_shm.py
+++ b/lmcache/v1/multiprocess/non_gpu_context_shm.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared-memory NonGpuContext implementation for multiprocess mode."""
+
+# Standard
+from multiprocessing.shared_memory import SharedMemory
+from typing import Any
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.multiprocess.non_gpu_context import (
+    NonGpuContext,
+    NonGpuContextMetadata,
+)
+from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+
+
+class NonGpuContextShm(NonGpuContext):
+    """Shared-memory implementation of :class:`NonGpuContext`.
+
+    Attaches to a named shared-memory segment on init and uses zero-copy
+    tensor views for data transfer. The server reserves slots and returns
+    offset/shape metadata; the worker constructs torch views directly into
+    shared memory.
+    """
+
+    def __init__(
+        self,
+        metadata: NonGpuContextMetadata,
+        mq_client: Any,
+        mq_timeout: float,
+        shm_name: str,
+        pool_size: int,
+    ) -> None:
+        super().__init__(metadata, mq_client, mq_timeout)
+        self._shm = SharedMemory(name=shm_name, create=False)
+        self._pool_size = pool_size
+        self._buffer = self._shm.buf
+
+    def _make_tensor_view(
+        self, offset: int, length: int, shape: list[int], dtype_str: str
+    ) -> torch.Tensor:
+        """Create a tensor view into the shared-memory buffer."""
+        dtype = getattr(torch, dtype_str)
+        t = torch.frombuffer(self._buffer, dtype=dtype, count=length // dtype.itemsize, offset=offset)
+        return t.view(shape)
+
+    def prepare_store(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
+        """Send PREPARE_STORE RPC and return pre-allocated SHM tensor views."""
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_STORE,
+            [key, instance_id],
+            get_response_class(RequestType.PREPARE_STORE),
+        )
+        try:
+            response = future.result(timeout=self.mq_timeout)
+        except TimeoutError:
+            return None
+
+        slots = response.context.get("slots")
+        if not slots:
+            return None
+
+        views = []
+        for slot in slots:
+            view = self._make_tensor_view(
+                slot["offset"], slot["length"], slot["shape"], slot["dtype"]
+            )
+            views.append(view)
+        return views
+
+    def commit_store(
+        self, key: Any, instance_id: int, chunks: list[torch.Tensor]
+    ) -> bool:
+        """Notify server that data has been written to SHM (send empty bytes)."""
+        future = self.mq_client.submit_request(
+            RequestType.COMMIT_STORE,
+            [key, instance_id, b""],
+            get_response_class(RequestType.COMMIT_STORE),
+        )
+        try:
+            return bool(future.result(timeout=self.mq_timeout))
+        except TimeoutError:
+            return False
+
+    def prepare_retrieve(self, key: Any, instance_id: int) -> list[torch.Tensor] | None:
+        """Send PREPARE_RETRIEVE and return SHM tensor views on hit."""
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_RETRIEVE,
+            [key, instance_id],
+            get_response_class(RequestType.PREPARE_RETRIEVE),
+        )
+        try:
+            response = future.result(timeout=self.mq_timeout)
+        except TimeoutError:
+            return None
+
+        if not response.success:
+            return None
+
+        slots = response.context.get("slots")
+        if not slots:
+            return None
+
+        views = []
+        for slot in slots:
+            view = self._make_tensor_view(
+                slot["offset"], slot["length"], slot["shape"], slot["dtype"]
+            )
+            views.append(view)
+        return views
+
+    def commit_retrieve(self, key: Any, instance_id: int) -> bool:
+        """Release read locks on the server side."""
+        future = self.mq_client.submit_request(
+            RequestType.COMMIT_RETRIEVE,
+            [key, instance_id],
+            get_response_class(RequestType.COMMIT_RETRIEVE),
+        )
+        try:
+            future.result(timeout=self.mq_timeout)
+        except TimeoutError:
+            pass
+        return True
+
+    def close(self) -> None:
+        """Release buffer and close shared memory attachment."""
+        self._buffer = None
+        try:
+            self._shm.close()
+        except Exception:
+            pass

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -43,6 +43,14 @@ class PrepareRetrieveResponse:
     context: dict = field(default_factory=dict)  # pickle: {}, shm will put slot info here
 
 
+@dataclass
+class RegisterNonGpuContextResponse:
+    """Response for REGISTER_KV_CACHE_NON_GPU_CONTEXT."""
+
+    shm_name: str = ""  # empty string means pickle mode
+    pool_size: int = 0  # 0 means pickle mode
+
+
 # Define request names for this protocol group
 REQUEST_NAMES = [
     "REGISTER_KV_CACHE",
@@ -179,7 +187,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Returns: None
         "REGISTER_KV_CACHE_NON_GPU_CONTEXT": ProtocolDefinition(
             payload_classes=[RegisterNonGpuContextPayload],
-            response_class=None,
+            response_class=RegisterNonGpuContextResponse,
             handler_type=HandlerType.SYNC,
         ),
         "PREPARE_STORE": ProtocolDefinition(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -72,6 +72,7 @@ from lmcache.v1.multiprocess.protocol import (
 from lmcache.v1.multiprocess.protocols.engine import (
     PrepareRetrieveResponse,
     PrepareStoreResponse,
+    RegisterNonGpuContextResponse,
 )
 from lmcache.v1.multiprocess.session import SessionManager
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
@@ -337,13 +338,16 @@ class MPCacheEngine:
     def register_kv_cache_non_gpu_context(
         self,
         payload: RegisterNonGpuContextPayload,
-    ) -> None:
+    ) -> RegisterNonGpuContextResponse:
         """Register non-CUDA KV layout metadata for non-GPU context mode.
 
         Args:
             payload: Struct containing all registration fields
                 (instance_id, model_name, world_size, block_size,
                 num_layers, hidden_dim_size, dtype_str, use_mla).
+
+        Returns:
+            RegisterNonGpuContextResponse with SHM pool info (or empty for pickle).
 
         Raises:
             ValueError: If ``payload.dtype_str`` is not a valid torch dtype name.
@@ -354,7 +358,12 @@ class MPCacheEngine:
                 "skipping the new registration",
                 payload.instance_id,
             )
-            return
+            # Still return pool info for re-registered workers
+            pool_info = self.storage_manager.get_shm_pool_info()
+            return RegisterNonGpuContextResponse(
+                shm_name=str(pool_info.get("shm_name", "")),
+                pool_size=int(pool_info.get("pool_size", 0)),
+            )
 
         dtype = getattr(torch, payload.dtype_str, None)
         if dtype is None or not isinstance(dtype, torch.dtype):
@@ -381,6 +390,20 @@ class MPCacheEngine:
                 use_mla=payload.use_mla,
             ),
         )
+
+        pool_info = self.storage_manager.get_shm_pool_info()
+        shm_name = str(pool_info.get("shm_name", ""))
+        pool_size = int(pool_info.get("pool_size", 0))
+        if shm_name:
+            logger.info(
+                "Non-GPU context registered with SHM mode "
+                "(shm_name=%s, pool_size=%d)",
+                shm_name,
+                pool_size,
+            )
+        else:
+            logger.info("Non-GPU context registered with pickle mode")
+        return RegisterNonGpuContextResponse(shm_name=shm_name, pool_size=pool_size)
 
     def _resolve_obj_keys(self, key: IPCCacheEngineKey) -> list[ObjectKey]:
         """Resolve object keys from an IPC cache key.
@@ -409,17 +432,48 @@ class MPCacheEngine:
         key: IPCCacheEngineKey,
         instance_id: int,
     ) -> PrepareStoreResponse:
-        """Prepare a store operation. For pickle mode, returns empty slots.
+        """Prepare a store operation.
+
+        For SHM mode: reserves write slots and returns offset metadata.
+        For pickle mode: returns empty context.
 
         Args:
             key: Cache key for the token range to store.
             instance_id: Worker instance identifier.
 
         Returns:
-            PrepareStoreResponse with empty slots for pickle mode.
+            PrepareStoreResponse with slot metadata for SHM or empty for pickle.
         """
+        pool_info = self.storage_manager.get_shm_pool_info()
+        if not pool_info.get("shm_name"):
+            return PrepareStoreResponse(context={})
 
-        return PrepareStoreResponse(context={})
+        # SHM mode: resolve keys and reserve write slots
+        obj_keys = self._resolve_obj_keys(key)
+        context = self.contexts.get(instance_id)
+        if context is None or context.non_cuda_metadata is None:
+            return PrepareStoreResponse(context={})
+
+        ctx = context.non_cuda_metadata
+        reserved_dict = self.storage_manager.reserve_write(
+            obj_keys, ctx.layout_desc, "new"
+        )
+
+        slots = []
+        for obj_key in obj_keys:
+            if obj_key not in reserved_dict:
+                continue
+            memory_obj = reserved_dict[obj_key]
+            if memory_obj.tensor is None:
+                continue
+            slots.append({
+                "offset": memory_obj.shm_offset,
+                "length": memory_obj.shm_byte_length,
+                "shape": list(memory_obj.tensor.shape),
+                "dtype": str(memory_obj.tensor.dtype).replace("torch.", ""),
+            })
+
+        return PrepareStoreResponse(context={"slots": slots} if slots else {})
 
     @_lmcache_nvtx_annotate
     def commit_store(
@@ -428,12 +482,16 @@ class MPCacheEngine:
         instance_id: int,
         cpu_data: bytes,
     ) -> bool:
-        """Commit serialized CPU chunks to storage.
+        """Commit store operation.
+
+        SHM mode (cpu_data is empty): data already written to SHM by worker,
+        just finalize the write.
+        Pickle mode: deserialize and copy data.
 
         Args:
             key: Cache key for the token range to store.
             instance_id: Worker instance identifier.
-            cpu_data: Pickled list of CPU tensors produced by the worker.
+            cpu_data: Pickled list of CPU tensors (pickle) or empty bytes (SHM).
 
         Returns:
             ``True`` when all reserved objects are written, otherwise ``False``.
@@ -446,6 +504,13 @@ class MPCacheEngine:
                 f"non-CUDA context not registered for instance ID {instance_id}"
             )
         ctx = context.non_cuda_metadata
+
+        if not cpu_data:
+            # SHM mode: data already in shared memory, just finish write
+            self.storage_manager.finish_write(obj_keys)
+            return True
+
+        # Pickle mode: deserialize and copy
         chunks: list[torch.Tensor] = pickle.loads(cpu_data)
         reserved_dict = self.storage_manager.reserve_write(
             obj_keys, ctx.layout_desc, "new"
@@ -477,16 +542,18 @@ class MPCacheEngine:
         key: IPCCacheEngineKey,
         instance_id: int,
     ) -> PrepareRetrieveResponse:
-        """Retrieve prefetched chunks and return serialized CPU tensors.
+        """Retrieve prefetched chunks.
+
+        SHM mode: returns slot metadata so worker can read directly.
+        Pickle mode: serializes and returns data in response.
 
         Args:
             key: Cache key for the token range to retrieve.
             instance_id: Worker instance identifier.
 
         Returns:
-            PrepareRetrieveResponse with serialized data on hit.
+            PrepareRetrieveResponse with slot metadata (SHM) or serialized data (pickle).
         """
-
         obj_keys = self._resolve_obj_keys(key)
 
         context = self.contexts.get(instance_id)
@@ -495,6 +562,29 @@ class MPCacheEngine:
                 f"non-CUDA context not registered for instance ID {instance_id}"
             )
 
+        pool_info = self.storage_manager.get_shm_pool_info()
+        use_shm = bool(pool_info.get("shm_name"))
+
+        if use_shm:
+            # SHM mode: use unsafe_read on already-prefetched (read-locked) objects
+            good_keys, good_objs = self.storage_manager.unsafe_read(obj_keys)
+            if not good_objs or len(good_objs) != len(obj_keys):
+                return PrepareRetrieveResponse(success=False, data=b"", context={})
+            slots = []
+            for memory_obj in good_objs:
+                if memory_obj.tensor is None:
+                    return PrepareRetrieveResponse(success=False, data=b"", context={})
+                slots.append({
+                    "offset": memory_obj.shm_offset,
+                    "length": memory_obj.shm_byte_length,
+                    "shape": list(memory_obj.tensor.shape),
+                    "dtype": str(memory_obj.tensor.dtype).replace("torch.", ""),
+                })
+            return PrepareRetrieveResponse(
+                success=True, data=b"", context={"slots": slots}
+            )
+
+        # Pickle mode
         prefetched_keys: list[ObjectKey] = []
         try:
             with self.storage_manager.read_prefetched_results(obj_keys) as memory_objs:
@@ -517,15 +607,23 @@ class MPCacheEngine:
         key: IPCCacheEngineKey,
         instance_id: int,
     ) -> bool:
-        """Finalize a retrieve operation. No-op for pickle mode.
+        """Finalize a retrieve operation.
+
+        SHM mode: releases read locks on the prefetched objects.
+        Pickle mode: no-op.
 
         Args:
-            key: Cache key (unused for pickle).
-            instance_id: Worker instance identifier (unused for pickle).
+            key: Cache key for the token range.
+            instance_id: Worker instance identifier.
 
         Returns:
             Always ``True``.
         """
+        pool_info = self.storage_manager.get_shm_pool_info()
+        if pool_info.get("shm_name"):
+            # SHM mode: release read locks
+            obj_keys = self._resolve_obj_keys(key)
+            self.storage_manager.finish_read_prefetched(obj_keys)
         return True
 
     @_lmcache_nvtx_annotate

--- a/lmcache/v1/multiprocess/transfer_context.py
+++ b/lmcache/v1/multiprocess/transfer_context.py
@@ -297,8 +297,28 @@ class NonCudaTransferContext(TransferContext):
             block_size=block_size,
             use_mla=use_mla_flag,
         )
-        self._non_gpu_context = create_non_gpu_context(metadata, mq_client, mq_timeout)
-        future.result(timeout=mq_timeout)
+        register_response = future.result(timeout=mq_timeout)
+
+        # Parse SHM info from register response
+        shm_name = ""
+        pool_size = 0
+        if register_response is not None:
+            shm_name = getattr(register_response, "shm_name", "") or ""
+            pool_size = getattr(register_response, "pool_size", 0) or 0
+
+        if shm_name:
+            logger.info(
+                "Non-GPU context registered with SHM mode "
+                "(shm_name=%s, pool_size=%d)",
+                shm_name,
+                pool_size,
+            )
+        else:
+            logger.info("Non-GPU context registered with pickle mode")
+
+        self._non_gpu_context = create_non_gpu_context(
+            metadata, mq_client, mq_timeout, shm_name=shm_name, pool_size=pool_size
+        )
 
     def submit_store(
         self,


### PR DESCRIPTION
## Summary

Adds a shared-memory based NonGpuContext implementation that enables zero-copy KV chunk transfer between worker and multiprocess server processes.

### Changes
- **`non_gpu_context_shm.py`**: `NonGpuContextShm` class implementing the two-phase store/retrieve ABC interface using a pre-allocated SHM pool
- **`protocols/base.py`**: Added `PREPARE_STORE`, `COMMIT_STORE`, `PREPARE_RETRIEVE`, `FINISH_READ` request types
- **`protocols/engine.py`**: Added `ShmSlotMetadata`, `PrepareStoreResponse`, `PrepareRetrieveResponse` structs and protocol definitions
- **`tests/v1/distributed/test_shm_l1_pool.py`**: Unit tests for SHM L1 pool

### Interface conformance
The SHM context implements the updated ABC:
- `prepare_store(key, instance_id, num_chunks, chunk_shape, dtype) -> (handle, shm_views)`
- `commit_store(handle, chunks) -> bool`
- `prepare_retrieve(key, instance_id) -> (handle, chunks)`
- `commit_retrieve(handle) -> None`

Ported from `copilot/port-commit-2fba18f5` and adapted to the new out-param interface.